### PR TITLE
Rast ng probably ready to merge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgrass7
 Version: 0.2-8
-Date: 2022-02-18
+Date: 2022-03-04
 Title: Interface Between GRASS Geographical Information System and R
 Authors@R: c(
 	person("Roger", "Bivand", role = c("cre", "aut"), email = "Roger.Bivand@nhh.no", comment=c(ORCID="0000-0003-2392-6140")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgrass7
-Version: 0.2-7
-Date: 2022-02-16
+Version: 0.2-8
+Date: 2022-02-18
 Title: Interface Between GRASS Geographical Information System and R
 Authors@R: c(
 	person("Roger", "Bivand", role = c("cre", "aut"), email = "Roger.Bivand@nhh.no", comment=c(ORCID="0000-0003-2392-6140")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rgrass7
 Version: 0.2-7
-Date: 2022-01-21
+Date: 2022-02-16
 Title: Interface Between GRASS Geographical Information System and R
 Authors@R: c(
 	person("Roger", "Bivand", role = c("cre", "aut"), email = "Roger.Bivand@nhh.no", comment=c(ORCID="0000-0003-2392-6140")),
@@ -22,5 +22,5 @@ License: GPL (>= 2)
 URL: https://grass.osgeo.org/, https://github.com/rsbivand/rgrass, https://rsbivand.github.io/rgrass/
 BugReports: https://github.com/rsbivand/rgrass/issues/
 Collate: AAA.R options.R rgrass.R bin_link.R rast_link.R vect_link.R
-        initGRASS.R xml1.R
+        vect_link_ng.R initGRASS.R xml1.R
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,11 +16,11 @@ Description: Interpreted interface between 'GRASS' geographical
     'spgrass6' should be used.
 Depends: R (>= 3.3.0), XML
 Imports: stats, utils, methods
-Suggests: rgdal (>= 1.0-6), RSQLite, sp (>= 0.9), sf (>= 0.7.6), stars
+Suggests: rgdal (>= 1.0-6), RSQLite, sp (>= 0.9), sf (>= 0.7.6), stars, terra
 SystemRequirements: GRASS (>= 7)
 License: GPL (>= 2)
 URL: https://grass.osgeo.org/, https://github.com/rsbivand/rgrass, https://rsbivand.github.io/rgrass/
 BugReports: https://github.com/rsbivand/rgrass/issues/
-Collate: AAA.R options.R rgrass.R bin_link.R vect_link.R initGRASS.R
-        xml1.R
+Collate: AAA.R options.R rgrass.R bin_link.R rast_link.R vect_link.R
+        initGRASS.R xml1.R
 RoxygenNote: 6.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -22,6 +22,8 @@ export(set.ignore.stderrOption, get.ignore.stderrOption, set.useGDALOption,
  get.defaultFlagsOption, set.defaultFlagsOption,
  get.suppressEchoCmdInFuncOption, set.suppressEchoCmdInFuncOption)
 
+export(read_VECT, write_VECT, read_RAST, write_RAST)
+
 S3method(print, gmeta)
 S3method(print, GRASS_interface_desc)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,7 +4,7 @@ import(XML)
 importFrom(utils, packageDescription, read.table)
 importFrom(stats, runif, na.omit)
 importFrom(methods, slot, "slot<-", as, "getMethod")
-importFrom("utils", "packageVersion")
+importFrom("utils", "packageVersion", "write.table")
 importFrom("grDevices", "rgb")
 
 export(gmeta, getLocationProj, gmeta2grd)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,8 +3,9 @@
 import(XML)
 importFrom(utils, packageDescription, read.table)
 importFrom(stats, runif, na.omit)
-importFrom(methods, slot, "slot<-", as)
+importFrom(methods, slot, "slot<-", as, "getMethod")
 importFrom("utils", "packageVersion")
+importFrom("grDevices", "rgb")
 
 export(gmeta, getLocationProj, gmeta2grd)
 export(execGRASS, stringexecGRASS, doGRASS, parseGRASS, getXMLencoding, setXMLencoding)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# version 0.2-7 (development)
+# version 0.2-8 (development)
 
 * **rgrass7** will keep dual old/new implementations, but old implementations will be deprecated at next version: `readRAST()`, `writeRAST()`, `readVECT()` and `writeVECT()`
 
@@ -7,6 +7,8 @@
 * add partial re-implementations of `read_RAST()` and `write_RAST()` using **terra** based on discussion in #42
 
 * add **terra** to `Suggests:`
+
+# version 0.2-7 (2022-01-28)
 
 * change repo name and links
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # version 0.2-8 (development)
 
+* `readRAST()`, `writeRAST()`, `readVECT()` and `writeVECT()` marked as deprecated
+
 * if a single `"SpatRaster"` not in memory is passed to write_RAST(), no temporary file is used, and the file name is passed directly to `r.in.gdal`
 
 * **rgrass7** will keep dual old/new implementations, but old implementations will be deprecated at next version: `readRAST()`, `writeRAST()`, `readVECT()` and `writeVECT()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # version 0.2-7 (development)
 
+* **rgrass7** will keep dual old/new implementations, but old implementations will be deprecated at next version: `readRAST()`, `writeRAST()`, `readVECT()` and `writeVECT()`
+
+* add partial re-implementations of `read_VECT()` and `write_VECT()` using **terra**
+
+* add partial re-implementations of `read_RAST()` and `write_RAST()` using **terra** based on discussion in #42
+
+* add **terra** to `Suggests:`
+
 * change repo name and links
 
 * use `g.remove` in `vect2neigh()` to avoid duplicate temporary files #36

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # version 0.2-8 (development)
 
+* if a single `"SpatRaster"` not in memory is passed to write_RAST(), no temporary file is used, and the file name is passed directly to `r.in.gdal`
+
 * **rgrass7** will keep dual old/new implementations, but old implementations will be deprecated at next version: `readRAST()`, `writeRAST()`, `readVECT()` and `writeVECT()`
 
-* add partial re-implementations of `read_VECT()` and `write_VECT()` using **terra**
+* add re-implementations of `read_VECT()` and `write_VECT()` using **terra**
 
-* add partial re-implementations of `read_RAST()` and `write_RAST()` using **terra** based on discussion in #42
+* add re-implementations of `read_RAST()` and `write_RAST()` using **terra** based on discussion in #42
 
 * add **terra** to `Suggests:`
 

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -47,7 +47,7 @@ if(!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
   else {
     gv <- .grassVersion()
     comp <- .compatibleGRASSVersion(gv)
-    if ( !comp ){
+    if (!is.na(comp) && !comp ){
         stop( attr(comp, "message") )
     }
     assign("GV", gv, envir=.GRASS_CACHE)

--- a/R/bin_link.R
+++ b/R/bin_link.R
@@ -6,6 +6,8 @@ readRAST <- function(vname, cat=NULL, ignore.stderr=get.ignore.stderrOption(),
 	NODATA=NULL, plugin=get.pluginOption(), mapset=NULL, 
         useGDAL=get.useGDALOption(), close_OK=TRUE, drivername="GTiff",
         driverFileExt=NULL, return_SGDF=TRUE) {
+    .Deprecated(new="read_RAST", package="rgrass7", old="readRAST",
+        msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
 
     R_in_sp <- isTRUE(.get_R_interface() == "sp")
 
@@ -397,6 +399,8 @@ writeRAST <- function(x, vname, zcol = 1, NODATA=NULL,
 	ignore.stderr = get.ignore.stderrOption(), useGDAL=get.useGDALOption(), overwrite=FALSE, flags=NULL,
         drivername="GTiff") {
 
+        .Deprecated(new="write_RAST", package="rgrass7", old="writeRAST",
+           msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
         if (get.suppressEchoCmdInFuncOption()) {
             inEchoCmd <- set.echoCmdOption(FALSE)
         }

--- a/R/bin_link.R
+++ b/R/bin_link.R
@@ -7,7 +7,7 @@ readRAST <- function(vname, cat=NULL, ignore.stderr=get.ignore.stderrOption(),
         useGDAL=get.useGDALOption(), close_OK=TRUE, drivername="GTiff",
         driverFileExt=NULL, return_SGDF=TRUE) {
     .Deprecated(new="read_RAST", package="rgrass7", old="readRAST",
-        msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
+        msg="Package rgrass7 is transitioning to package rgrass for GRASS GIS 8.\n'readRAST' is deprecated. Use 'read_RAST' instead.")
 
     R_in_sp <- isTRUE(.get_R_interface() == "sp")
 

--- a/R/bin_link.R
+++ b/R/bin_link.R
@@ -400,7 +400,7 @@ writeRAST <- function(x, vname, zcol = 1, NODATA=NULL,
         drivername="GTiff") {
 
         .Deprecated(new="write_RAST", package="rgrass7", old="writeRAST",
-           msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
+           msg="Package rgrass7 transitioning to package rgrass for GRASS 8.\n'writeRAST' is deprecated. Use 'write_RAST' instead.")
         if (get.suppressEchoCmdInFuncOption()) {
             inEchoCmd <- set.echoCmdOption(FALSE)
         }

--- a/R/bin_link.R
+++ b/R/bin_link.R
@@ -223,6 +223,7 @@ readRAST <- function(vname, cat=NULL, ignore.stderr=get.ignore.stderrOption(),
                                     catlabs <- paste(catlabs, catnos, sep="_")
                                     warning("non-unique category labels; category number appended")
                                 }
+# https://files.nc.gov/ncdeq/Energy+Mineral+and+Land+Resources/Geological+Survey/1985_state_geologic_map_500000_scale.pdf (catnos vector polygon IDs)
 				resa@data[[i]] <- factor(resa@data[[i]], 
 					levels=catnos, labels=catlabs)
 			}

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -249,13 +249,8 @@ initGRASS <- function(gisBase, home, SG, gisDbase, addon_base, location,
     if (!file.exists(pfile)) {
         mSG <- !missing(SG)
         if (mSG) {
-          if (!inherits(SG, "Spatial"))
-            stop("SG is of class", class(SG), "not inheriting from Spatial")
-          R_in_sp <- isTRUE(.get_R_interface() == "sp")
-          if (is.null(.get_R_interface()) || !R_in_sp) {
-            use_sp()
-            warning("use_sp() was set because SG was given")
-          }
+            if (!requireNamespace("sp", quietly=TRUE))
+                stop("The sp package is required for the SG argument")
         }
         if (mSG) bb <- sp::bbox(SG)
         if (mSG) gt <- sp::gridparameters(SG)
@@ -295,14 +290,14 @@ initGRASS <- function(gisBase, home, SG, gisDbase, addon_base, location,
     tfile <- paste(loc_path, mapset, "WIND", sep="/")
     if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
     if (mSG) {
-        if (nzchar(wkt(SG))) {
+        if (nzchar(sp::wkt(SG))) {
             tf <- tempfile()
-            writeLines(wkt(SG), con=tf)
-	    execGRASS("g.mapset", mapset="PERMANENT", flag="quiet")
+            writeLines(sp::wkt(SG), con=tf)
+	    execGRASS("g.mapset", mapset="PERMANENT", flags="quiet")
             tull <- execGRASS("g.proj", flags="c", wkt=tf, ignore.stderr=TRUE,
                 intern=TRUE)
-            execGRASS("g.mapset", mapset=mapset, flag="quiet")
-	    execGRASS("g.region", flag="d", ignore.stderr=TRUE)
+            execGRASS("g.mapset", mapset=mapset, flags="quiet")
+	    execGRASS("g.region", flags="d", ignore.stderr=TRUE)
         }
     }
     gmeta()

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -249,6 +249,7 @@ initGRASS <- function(gisBase, home, SG, gisDbase, addon_base, location,
     
     assign("GV", gv, envir=.GRASS_CACHE)
     pfile <- paste(loc_path, "PERMANENT", "DEFAULT_WIND", sep="/")
+    mSG <- FALSE
     if (!file.exists(pfile)) {
         lonlat <- FALSE
         mSG <- !missing(SG)
@@ -315,7 +316,7 @@ initGRASS <- function(gisBase, home, SG, gisDbase, addon_base, location,
     if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
     tfile <- paste(loc_path, mapset, "WIND", sep="/")
     if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
-    execGRASS("g.region", save="input")
+    execGRASS("g.region", save="input", flags="overwrite")
     if (mSG) {
         if (nzchar(wkt_SG)) {
             tf <- tempfile()

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -1,3 +1,6 @@
+# Interpreted GRASS 7, 8 raster interface functions
+# Copyright (c) 2008-22 Roger S. Bivand
+#
 # GIS_LOCK 110814 RSB, suggested by Brian Oney
 get.GIS_LOCK <- function() {
     Sys.getenv("GIS_LOCK")
@@ -247,14 +250,36 @@ initGRASS <- function(gisBase, home, SG, gisDbase, addon_base, location,
     assign("GV", gv, envir=.GRASS_CACHE)
     pfile <- paste(loc_path, "PERMANENT", "DEFAULT_WIND", sep="/")
     if (!file.exists(pfile)) {
+        lonlat <- FALSE
         mSG <- !missing(SG)
         if (mSG) {
-            if (!requireNamespace("sp", quietly=TRUE))
-                stop("The sp package is required for the SG argument")
+            if (inherits(SG, "SpatialGrid")) {
+                if (!requireNamespace("sp", quietly=TRUE))
+                    stop("The sp package is required for the SG argument")
+                bb <- sp::bbox(SG)
+                gt <- sp::gridparameters(SG)
+                wkt_SG <- sp::wkt(SG)
+                lonlatSG <- sp::is.projected(SG)
+            } else if (inherits(SG, "SpatRaster")) {
+                if (!requireNamespace("terra", quietly=TRUE))
+                    stop("The terra package is required for the SG argument")
+                bb <- getMethod("ext", "SpatRaster")(SG)@ptr$vector
+                bb <- matrix(bb, 2, 2, byrow=TRUE)
+                colnames(bb) <- c("min", "max")
+                cs <- getMethod("res", "SpatRaster")(SG)
+                co <- bb[,1]+(cs/2)
+                cd <- c(getMethod("ncol", "SpatRaster")(SG), 
+                    getMethod("nrow", "SpatRaster")(SG))
+                gt <- data.frame(cellcentre.offset=co, cellsize=cs,
+                    cells.dim=cd)
+                wkt_SG <- getMethod("crs", "SpatRaster")(SG)
+                lonlatSG <- getMethod("is.lonlat", "SpatRaster")(SG)
+            } else {
+                stop ("SG must be a terra or SpatialGrid object")
+            }
+            lonlat <- !is.na(lonlatSG) && lonlatSG
         }
-        if (mSG) bb <- sp::bbox(SG)
-        if (mSG) gt <- sp::gridparameters(SG)
-        cat("proj:       0\n", file=pfile)
+        cat("proj:       ", ifelse(lonlat, 3, 99), "\n", file=pfile)
         cat("zone:       0\n", file=pfile, append=TRUE)
         cat("north:      ", ifelse(mSG, bb[2, "max"], 1), "\n",
             sep="", file=pfile, append=TRUE)
@@ -285,19 +310,22 @@ initGRASS <- function(gisBase, home, SG, gisDbase, addon_base, location,
             sep="", file=pfile, append=TRUE)
         cat("t-b resol:  1\n", sep="", file=pfile, append=TRUE)
     }
+    
     tfile <- paste(loc_path, "PERMANENT", "WIND", sep="/")
     if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
     tfile <- paste(loc_path, mapset, "WIND", sep="/")
     if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
+    execGRASS("g.region", save="input")
     if (mSG) {
-        if (nzchar(sp::wkt(SG))) {
+        if (nzchar(wkt_SG)) {
             tf <- tempfile()
-            writeLines(sp::wkt(SG), con=tf)
+            writeLines(wkt_SG, con=tf)
 	    execGRASS("g.mapset", mapset="PERMANENT", flags="quiet")
             tull <- execGRASS("g.proj", flags="c", wkt=tf, ignore.stderr=TRUE,
                 intern=TRUE)
+            execGRASS("g.region", flags="s", region=paste0("input@", mapset))
+            execGRASS("g.region", flags="d", ignore.stderr=TRUE)
             execGRASS("g.mapset", mapset=mapset, flags="quiet")
-	    execGRASS("g.region", flags="d", ignore.stderr=TRUE)
         }
     }
     gmeta()

--- a/R/rast_link.R
+++ b/R/rast_link.R
@@ -1,0 +1,449 @@
+# Interpreted GRASS 7, 8 raster interface functions
+# Copyright (c) 2022 Roger S. Bivand
+#
+
+read_RAST <- function(vname, cat=NULL, NODATA=NULL, 
+    ignore.stderr=get.ignore.stderrOption(), return_format="SGDF", 
+    close_OK=return_format=="SGDF", flgs=NULL) {
+
+    if (!is.null(cat))
+        if(length(vname) != length(cat)) 
+	    stop("vname and cat not same length")
+    if (get.suppressEchoCmdInFuncOption()) {
+        inEchoCmd <- set.echoCmdOption(FALSE)
+    }
+    if (close_OK) {
+        openedConns <- as.integer(row.names(showConnections()))
+    }
+    stopifnot(is.logical(ignore.stderr))
+
+    if (!is.null(NODATA)) {
+        if (any(!is.finite(NODATA)) || any(!is.numeric(NODATA)))
+            stop("invalid NODATA value")
+	if (NODATA != round(NODATA)) 
+	    warning("NODATA rounded to integer")
+	NODATA <- round(NODATA)
+        if (length(NODATA) != length(vname)) 
+            NODATA <- rep(NODATA[1], length.out=length(vname))
+     }
+
+    if (return_format == "SGDF") {
+        if (!(requireNamespace("sp", quietly=TRUE)))
+            stop("sp required for SGDF output")
+        resa <- .read_rast_non_plugin_ng(vname=vname, cat=cat, NODATA=NODATA, 
+            ignore.stderr=ignore.stderr)
+        if (close_OK) { #closeAllConnections()
+            openConns_now <- as.integer(row.names(showConnections()))
+            toBeClosed <- openConns_now[!(openConns_now %in% openedConns)]
+            for (bye in toBeClosed) close(bye)
+        }
+    } else {
+        if (!(requireNamespace("terra", quietly=TRUE))) 
+            stop("terra required for terra output")
+        reslist <- vector(mode="list", length=length(vname))
+        names(reslist) <- vname
+        tmplist <- vector(mode="list", length=length(vname))
+        names(tmplist) <- vname
+        for (i in seq(along=vname)) {
+# 130422 at rgdal 0.8-8 GDAL.close(DS)
+# 061107 Dylan Beaudette NODATA
+# 071009 Markus Neteler's idea to use range
+            if (is.null(NODATA)) {
+	        tx <- execGRASS("r.info", flags="r", map=vname[i], intern=TRUE, 
+	            ignore.stderr=ignore.stderr)
+	        tx <- gsub("=", ":", tx)
+	        con <- textConnection(tx)
+                res <- read.dcf(con)
+	        close(con)
+	        lres <- as.list(res)
+	        names(lres) <- colnames(res)
+	        lres <- lapply(lres, function(x)
+                ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
+	        if (!is.numeric(lres$min) || 
+	           !is.finite(as.double(lres$min))) 
+                     NODATAi <- as.integer(999)
+	        else {
+	            lres$min <- floor(as.double(lres$min))
+	            NODATAi <- floor(lres$min) - 1
+	        }
+            } else NODATAi <- NODATA[i]
+            tmplist[[i]] <- tempfile(fileext=".grd")
+            if (is.null(flgs)) flgs <- c("overwrite", "c", "m")
+            if (!is.null(cat) && cat[i]) flgs <- c(flgs, "t")
+            execGRASS("r.out.gdal", input=vname[i], output=tmplist[[i]],
+                format="RRASTER", nodata=NODATAi, flags=flgs,
+                ignore.stderr=ignore.stderr)
+            reslist[[i]] <- getMethod("rast", "character")(tmplist[[i]])
+        }         
+        resa <- getMethod("rast", "list")(reslist)
+    }
+    if (get.suppressEchoCmdInFuncOption()) tull <- set.echoCmdOption(inEchoCmd)
+    
+    resa
+}
+
+
+.read_rast_non_plugin_ng <- function(vname, cat, NODATA, ignore.stderr) {
+    
+    pid <- as.integer(round(runif(1, 1, 1000)))
+        
+    gLP <- getLocationProj()
+    if (gLP == "XY location (unprojected)")
+        p4 <- sp::CRS(as.character(NA))
+    else
+        p4 <- sp::CRS(gLP)
+
+    reslist <- vector(mode="list", length=length(vname))
+    names(reslist) <- vname
+
+    for (i in seq(along=vname)) {
+
+        glist <- execGRASS("r.info", flags="g", map=vname[i],
+            intern=TRUE, ignore.stderr=ignore.stderr)
+        whCELL <- glist[grep("datatype", glist)]
+	to_int <- length(which(unlist(strsplit(
+	    whCELL, "=")) == "CELL")) > 0
+        Dcell <- length(which(unlist(strsplit(
+	    whCELL, "=")) == "DCELL")) > 0
+
+	gtmpfl1 <- dirname(execGRASS("g.tempfile",
+	    pid=pid, intern=TRUE, ignore.stderr=ignore.stderr))
+	rtmpfl1 <- ifelse(.Platform$OS.type == "windows" &&
+            (Sys.getenv("OSTYPE") == "cygwin"), 
+	    system(paste("cygpath -w", gtmpfl1, sep=" "), 
+	    intern=TRUE), gtmpfl1)
+	gtmpfl11 <- paste(gtmpfl1, vname[i], sep=.Platform$file.sep)
+	rtmpfl11 <- paste(rtmpfl1, vname[i], sep=.Platform$file.sep)
+
+# 130422 at rgdal 0.8-8 GDAL.close(DS)
+# 061107 Dylan Beaudette NODATA
+# 071009 Markus Neteler's idea to use range
+    if (is.null(NODATA)) {
+	tx <- execGRASS("r.info", flags="r", map=vname[i], intern=TRUE, 
+	    ignore.stderr=ignore.stderr)
+	tx <- gsub("=", ":", tx)
+	con <- textConnection(tx)
+        res <- read.dcf(con)
+	close(con)
+	lres <- as.list(res)
+	names(lres) <- colnames(res)
+	lres <- lapply(lres, function(x)
+        ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
+	if (!is.numeric(lres$min) || 
+	    !is.finite(as.double(lres$min))) 
+            NODATAi <- as.integer(999)
+	else {
+	    lres$min <- floor(as.double(lres$min))
+	    NODATAi <- floor(lres$min) - 1
+	}
+    }
+
+        rOutBinFlags <- "b"
+# 120118 Rainer Krug
+        if (to_int) rOutBinFlags <- c(rOutBinFlags, "i")
+        else rOutBinFlags <- c(rOutBinFlags, "f")
+        rOutBinBytes <- 4L
+        if (Dcell) rOutBinBytes <- 8L
+        tryCatch({
+	    execGRASS("r.out.bin", flags=rOutBinFlags, 
+                input=vname[i], output=gtmpfl11, bytes=rOutBinBytes,
+                null=as.integer(NODATAi), ignore.stderr=ignore.stderr)
+                        
+                gdal_info <- bin_gdal_info_ng(rtmpfl11, to_int)
+                        
+                what <- ifelse(to_int, "integer", "double")
+                n <- gdal_info[1] * gdal_info[2]
+                size <- gdal_info[10]/8
+                        
+                reslist[[i]] <- readBinGridData(rtmpfl11, what=what,
+                    n=n, size=size, endian=attr(gdal_info, "endian"),
+                    nodata=attr(gdal_info, "nodata"))
+            }, finally = {
+                unlink(paste(rtmpfl1, list.files(rtmpfl1,
+                    pattern=vname[i]), sep=.Platform$file.sep))
+            }
+        )
+    }
+
+    co <- unname(c((gdal_info[4] + (gdal_info[6]/2)),
+        (gdal_info[5] + (gdal_info[7]/2))))
+    grid <- sp::GridTopology(co, unname(c(gdal_info[6], gdal_info[7])),
+        unname(c(gdal_info[2], gdal_info[1])))
+
+    if (length(unique(sapply(reslist, length))) != 1)
+        stop ("bands differ in length")
+
+    df <- as.data.frame(reslist)
+
+    resa <- sp::SpatialGridDataFrame(grid=grid, data=df, proj4string=p4)
+
+    if (!is.null(cat)) {
+	for (i in seq(along=cat)) {
+	    if (cat[i] && is.integer(resa@data[[i]])) {
+
+	        rSTATS <- execGRASS("r.stats", flags=c("l", "quiet"),
+	            input=vname[i], intern=TRUE,
+                    ignore.stderr=ignore.stderr)
+
+		cats <- strsplit(rSTATS, " ")
+		catnos <- sapply(cats, function(x) x[1])
+		catlabs <- sapply(cats, 
+		    function(x) paste(x[-1], collapse=" "))
+		if (any(!is.na(match(catnos, "*")))) {
+		    isNA <- which(catnos == "*")
+		    catnos <- catnos[-isNA]
+		    catlabs <- catlabs[-isNA]
+		}
+                if (length(catlabs) > length(unique(catlabs))) {
+                    catlabs <- paste(catlabs, catnos, sep="_")
+                    warning("non-unique category labels; category number appended")
+                }
+# https://files.nc.gov/ncdeq/Energy+Mineral+and+Land+Resources/Geological+Survey/1985_state_geologic_map_500000_scale.pdf (catnos vector polygon IDs)
+		resa@data[[i]] <- factor(resa@data[[i]], 
+		    levels=catnos, labels=catlabs)
+            }
+	} 
+    }
+    return(resa)
+}
+
+
+
+
+bin_gdal_info_ng <- function(fname, to_int) {
+	if (!file.exists(fname)) stop(paste("no such file:", fname))
+	if (!file.exists(paste(fname, "hdr", sep="."))) 
+		stop(paste("no such file:", paste(fname, "hdr", sep=".")))
+	if (!file.exists(paste(fname, "wld", sep="."))) 
+		stop(paste("no such file:", paste(fname, "wld", sep=".")))
+	con <- file(paste(fname, "hdr", sep="."), "r")
+	l8 <- readLines(con, n=8)
+	close(con)
+	l8 <- read.dcf(con <- textConnection(gsub(" ", ":", l8)))
+	close(con)
+	lres <- as.list(l8)
+	names(lres) <- colnames(l8)
+	lres$nrows <- as.integer(lres$nrows)
+	lres$ncols <- as.integer(lres$ncols)
+	lres$nbands <- as.integer(lres$nbands)
+	lres$nbits <- as.integer(lres$nbits)
+	lres$skipbytes <- as.integer(lres$skipbytes)
+	lres$nodata <- ifelse(to_int, as.integer(lres$nodata), 
+		as.numeric(lres$nodata))
+	lres$byteorder <- as.character(lres$byteorder)
+	endian <- .Platform$endian
+	if ((endian == "little" && lres$byteorder == "M") ||
+		(endian == "big" && lres$byteorder == "I")) endian <- "swap"
+	con <- file(paste(fname, "wld", sep="."), "r")
+	l6 <- readLines(con, n=6)
+	close(con)
+	lres$ewres <- abs(as.numeric(l6[1]))
+	lres$nsres <- abs(as.numeric(l6[4]))
+	lres$n_cc <- as.numeric(l6[6])
+	lres$w_cc <- as.numeric(l6[5])
+	lres$s_cc <- lres$n_cc - lres$nsres * (lres$nrows-1)
+
+    outres <- numeric(10)
+    outres[1] <- lres$nrows
+    outres[2] <- lres$ncols
+    outres[3] <- lres$nbands
+    outres[4] <- lres$w_cc - (lres$ewres/2)
+    outres[5] <- lres$s_cc - (lres$nsres/2)
+    outres[6] <- lres$ewres
+    outres[7] <- lres$nsres
+    outres[10] <- lres$nbits
+    attr(outres, "endian") <- endian
+    attr(outres, "nodata") <- lres$nodata
+#	grid = GridTopology(c(lres$w_cc, lres$s_cc), 
+#		c(lres$ewres, lres$nsres), c(lres$ncols,lres$nrows))
+    outres
+}
+
+readBinGridData <- function(fname, what, n, size, endian, nodata) {
+    map <- readBin(fname, what=what, n=n, size=size, signed=TRUE,
+	endian=endian)
+    is.na(map) <- map == nodata
+    map
+}
+
+repair_cats <- function(x, layer, vname) {
+    if (!(requireNamespace("terra", quietly=TRUE))) 
+        stop("terra required for to repair terra object cats")
+    if (!inherits(x, "SpatRaster")) stop("x not a SpatRaster object")
+    xcats <- getMethod("cats", "SpatRaster")(x)
+    nms <- getMethod("names", "SpatRaster")(x)
+    if (length(xcats) > 1) {
+        nms <- getMethod("names", "SpatRaster")(x)
+        if (!(layer %in% nms)) stop("layer not found")
+    }
+    xcat <- xcats[[match(layer, nms)]]
+    if (is.null(xcat)) warning("no cats in layer")
+    zcats <- cats_internals(vname)
+    res <- vector(mode="list", length=1)
+    names(res) <- layer
+    res[[1]] <- getMethod("classify", "SpatRaster")(x[[layer]], zcats$rcp_out)
+    getMethod("set.cats", "SpatRaster")(res[[1]], layer=1, value=zcats$levs)
+    getMethod("rast", "list")(res)
+}
+
+cats_internals <- function(vname) {
+    cats <- execGRASS("r.category", map=vname, separator=":", intern=TRUE)
+    cats1 <- strsplit(cats, ":")
+    cats2 <- data.frame(ID=sapply(cats1, "[", 1L), 
+        category=sapply(cats1, "[", 2))
+    cats2$Icat <- as.integer(factor(cats2$category,
+        levels=unique(cats2$category)))
+    cats3 <- split(cats2, cats2$Icat)
+    rcp_out <- do.call("rbind", lapply(cats3, function(x) {
+        cbind(as.integer(x[[1]]), as.integer(x[[3]]))
+    }))
+    levs <- do.call("rbind", lapply(cats3, function(x) {
+        ux <- unique(x[, 2:3])
+        data.frame(cat=as.integer(ux[[2]]), lev=ux[[1]])
+    }))
+    list(rcp_out=rcp_out, levs=levs)
+}
+
+read_cat_colors <- function(vname) {
+    zcats <- cats_internals(vname)
+    cols <- execGRASS("r.colors.out", map=vname, intern=TRUE)
+    cols12 <- strsplit(cols, " ")
+    cat_col1 <- match(as.character(zcats$rcp_out[,1]), sapply(cols12, "[", 1))
+    if (length(cat_col1) != (length(cols12) - 2L)) 
+        warning("possible category mismatch")
+    coltb <- sapply(cols12[zcats$rcp_out[order(zcats$rcp_out[,1]), 2]], "[", 2L)
+    df <- as.data.frame(t(sapply(strsplit(coltb, ":"), as.integer)))
+    pal <- rgb(df$V1, df$V2, df$V3, maxColorValue=255)
+    list(coltab=df, pal=pal)
+}
+
+
+write_RAST <- function(x, vname, zcol = 1, NODATA=NULL, 
+	ignore.stderr = get.ignore.stderrOption(), useGDAL=get.useGDALOption(), overwrite=FALSE, flags=NULL,
+        drivername="GTiff") {
+
+        if (get.suppressEchoCmdInFuncOption()) {
+            inEchoCmd <- set.echoCmdOption(FALSE)
+        }
+
+        R_in_sp <- isTRUE(.get_R_interface() == "sp")
+
+        if (!R_in_sp) stop("no stars support yet")
+        tryCatch(
+            {
+                stopifnot(is.logical(ignore.stderr))
+                stopifnot(is.logical(useGDAL))
+                pid <- as.integer(round(runif(1, 1, 1000)))
+                gtmpfl1 <- dirname(execGRASS("g.tempfile", pid=pid,
+                                             intern=TRUE, ignore.stderr=ignore.stderr))
+                
+                rtmpfl1 <- ifelse(.Platform$OS.type == "windows" &&
+                                      (Sys.getenv("OSTYPE") == "cygwin"), 
+                                  system(paste("cygpath -w", gtmpfl1, sep=" "), intern=TRUE), 
+                                  gtmpfl1)
+                
+                fid <- paste("X", pid, sep="")
+                gtmpfl11 <- paste(gtmpfl1, fid, sep=.Platform$file.sep)
+                rtmpfl11 <- paste(rtmpfl1, fid, sep=.Platform$file.sep)
+                if (!is.numeric(x@data[[zcol]])) 
+                    stop("only numeric columns may be exported")
+                if (overwrite && !("overwrite" %in% flags))
+                    flags <- c(flags, "overwrite")
+                tryCatch(
+                    {
+                        res <- writeBinGrid_ng(x, rtmpfl11, attr = zcol, na.value = NODATA)
+                        
+                        flags <- c(res$flag, flags)
+                        
+                        execGRASS("r.in.bin", flags=flags,
+                                  input=gtmpfl11,
+                                  output=vname, bytes=as.integer(res$bytes), 
+                                  north=as.numeric(res$north), south=as.numeric(res$south), 
+                                  east=as.numeric(res$east), west=as.numeric(res$west), 
+                                  rows=as.integer(res$rows), cols=as.integer(res$cols), 
+                                  anull=as.numeric(res$anull), ignore.stderr=ignore.stderr)
+                    },
+                    finally = {
+                        unlink(paste(rtmpfl1, list.files(rtmpfl1, pattern=fid), 
+                                     sep=.Platform$file.sep))
+                    }
+                )
+            },
+            finally = {
+                if (get.suppressEchoCmdInFuncOption()) {
+                    tull <- set.echoCmdOption(inEchoCmd)
+                }
+            }
+        )
+
+	invisible(res)
+}
+
+writeBinGrid_ng <- function(x, fname, attr = 1, na.value = NULL) { 
+	if (!sp::gridded(x))
+		stop("can only write SpatialGridDataFrame objects to binary grid")
+	x = as(x, "SpatialGridDataFrame")
+	gp = sp::gridparameters(x)
+	if (length(gp$cells.dim) != 2)
+		stop("binary grid only supports 2D grids")
+	z = x@data[[attr]]
+	if (is.factor(z)) z <- as.numeric(z)
+	if (!is.numeric(z)) stop("only numeric values may be exported")
+	if (is.null(na.value)) {
+		na.value <- floor(min(z, na.rm=TRUE)) - 1
+	} else {
+		if (!is.finite(na.value) || !is.numeric(na.value))
+			stop("invalid NODATA value")
+		if (na.value != round(na.value)) 
+			warning("NODATA rounded to integer")
+		na.value <- round(na.value)
+	}
+	res <- list()
+	res$anull <- formatC(na.value, format="d")
+	z[is.na(z)] = as.integer(na.value)
+	if (storage.mode(z) == "integer") {
+		sz <- 4
+	} else if (storage.mode(z) == "double") {
+		sz <- 8
+		res$flag <- "d"
+	} else stop("unknown storage mode")
+	res$bytes <- formatC(sz, format="d")
+	f = file(fname, open = "wb")
+	writeBin(z, con=f, size=sz)
+	close(f)
+	grd <- slot(x, "grid")
+	f = file(paste(fname, "hdr", sep="."), open = "wt")
+	writeLines(paste("nrows", grd@cells.dim[2]), f)
+	res$rows <- formatC(grd@cells.dim[2], format="d")
+	writeLines(paste("ncols", grd@cells.dim[1]), f)
+	res$cols <- formatC(grd@cells.dim[1], format="d")
+	writeLines(paste("nbands 1"), f)
+	writeLines(paste("nbits", 8*sz), f)
+	writeLines(paste("byteorder", ifelse(.Platform$endian == "little", 
+		"I", "M")), f)
+	writeLines(paste("layout bil"), f)
+	writeLines(paste("skipbytes 0"), f)
+	writeLines(paste("nodata", na.value), f)
+	close(f)
+	f = file(paste(fname, "wld", sep="."), open = "wt")
+	writeLines(formatC(grd@cellsize[1], format="f"), f)
+	writeLines("0.0", f)
+	writeLines("0.0", f)
+	writeLines(formatC(-grd@cellsize[2], format="f"), f)
+	writeLines(formatC(grd@cellcentre.offset[1], format="f"), f)
+	writeLines(formatC((grd@cellcentre.offset[2] +
+		grd@cellsize[2]*(grd@cells.dim[2]-1)), format="f"), f)
+	close(f)
+	res$north <- formatC((grd@cellcentre.offset[2] +
+		grd@cellsize[2]*(grd@cells.dim[2]-1)
+		+ 0.5*grd@cellsize[2]), format="f")
+	res$south <- formatC(grd@cellcentre.offset[2] - 0.5*grd@cellsize[2], 
+		format="f")
+	res$east <- formatC((grd@cellcentre.offset[1] + 
+		grd@cellsize[1]*(grd@cells.dim[1]-1) + 0.5*grd@cellsize[1]), 
+		format="f")
+	res$west <- formatC(grd@cellcentre.offset[1] - 0.5*grd@cellsize[1], 
+		format="f")
+	invisible(res)
+}
+

--- a/R/rast_link.R
+++ b/R/rast_link.R
@@ -39,7 +39,7 @@ read_RAST <- function(vname, cat=NULL, NODATA=NULL,
         }
     } else {
         if (!(requireNamespace("terra", quietly=TRUE))) 
-            stop("terra required for terra output")
+            stop("terra required for SpatRaster output")
         reslist <- vector(mode="list", length=length(vname))
         names(reslist) <- vname
         tmplist <- vector(mode="list", length=length(vname))

--- a/R/rast_link.R
+++ b/R/rast_link.R
@@ -4,7 +4,7 @@
 
 read_RAST <- function(vname, cat=NULL, NODATA=NULL, 
     ignore.stderr=get.ignore.stderrOption(), return_format="SGDF", 
-    close_OK=return_format=="SGDF", flgs=NULL) {
+    close_OK=return_format=="SGDF", flags=NULL) {
 
     if (!is.null(cat))
         if(length(vname) != length(cat)) 
@@ -68,10 +68,10 @@ read_RAST <- function(vname, cat=NULL, NODATA=NULL,
 	        }
             } else NODATAi <- NODATA[i]
             tmplist[[i]] <- tempfile(fileext=".grd")
-            if (is.null(flgs)) flgs <- c("overwrite", "c", "m")
-            if (!is.null(cat) && cat[i]) flgs <- c(flgs, "t")
+            if (is.null(flags)) flags <- c("overwrite", "c", "m")
+            if (!is.null(cat) && cat[i]) flags <- c(flags, "t")
             execGRASS("r.out.gdal", input=vname[i], output=tmplist[[i]],
-                format="RRASTER", nodata=NODATAi, flags=flgs,
+                format="RRASTER", nodata=NODATAi, flags=flags,
                 ignore.stderr=ignore.stderr)
             reslist[[i]] <- getMethod("rast", "character")(tmplist[[i]])
         }         

--- a/R/rgrass.R
+++ b/R/rgrass.R
@@ -74,12 +74,12 @@ print.gmeta <- function(x, ...) {
 }
 
 gmeta2grd <- function(ignore.stderr = FALSE) {
+	if (!requireNamespace("sp", quietly=TRUE))
+		stop("sp required to creat a GridTopology object")
 	G <- gmeta(ignore.stderr=ignore.stderr)
 	cellcentre.offset <- c(G$w+(G$ewres/2), G$s+(G$nsres/2))
 	cellsize <- c(G$ewres, G$nsres)
 	cells.dim <- c(G$cols, G$rows)
-        R_in_sp <- isTRUE(.get_R_interface() == "sp")
-        if (!R_in_sp) stop("no stars grid yet")
 
 	grd <- sp::GridTopology(cellcentre.offset=cellcentre.offset, 
 		cellsize=cellsize, cells.dim=cells.dim)

--- a/R/rgrass.R
+++ b/R/rgrass.R
@@ -168,15 +168,22 @@ getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT=NULL) {
 
 
 .grassVersion <- function(ignore.stderr=TRUE) {
-    Gver <- execGRASS(
+    Gver <- try(execGRASS(
         "g.version",
         intern = TRUE, 
-        ignore.stderr = ignore.stderr)
+        ignore.stderr = ignore.stderr), silent=TRUE)
+    if (inherits(Gver, "try-error"))
+        Gver <- "sh: line 1: g.version: command not found"
     return(Gver)
 }
 
 .compatibleGRASSVersion <- function(gv=.grassVersion()) {
     compatible <- ( (gv >= "GRASS 7.0") & (gv < "GRASS 9.0") )
+    if (gv == "sh: line 1: g.version: command not found") {
+        compatible <- as.logical(NA)
+        attr(compatible, "message") <- gv
+        return(compatible)
+    }
     if ( !compatible ){
         attr(compatible, "message") <- paste0(
             "\n### rgrass7 is not compatible with the GRASS GIS version '", gv, "'!",

--- a/R/vect_link.R
+++ b/R/vect_link.R
@@ -5,6 +5,8 @@ readVECT <- function(vname, layer, type=NULL, plugin=NULL,
         remove.duplicates=TRUE, ignore.stderr = NULL,
         with_prj=TRUE,  with_c=FALSE, mapset=NULL, pointDropZ=FALSE,
         driver=NULL) {
+        .Deprecated(new="read_VECT", package="rgrass7", old="readVECT",
+            msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
         if (is.null(.get_R_interface())) 
        stop("use either use_sp() or use_sf() at session start to choose\n sp or sf/stars classes")
         R_in_sp <- isTRUE(.get_R_interface() == "sp")
@@ -390,6 +392,8 @@ writeVECT <- function(SDF, vname, #factor2char = TRUE,
     v.in.ogr_flags=NULL, ignore.stderr = NULL,
     driver=NULL, min_area=0.0001, snap=-1) {
 
+    .Deprecated(new="write_VECT", package="rgrass7", old="writeVECT",
+       msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
     R_in_sp <- isTRUE(.get_R_interface() == "sp")
 
     if (is.null(ignore.stderr))

--- a/R/vect_link.R
+++ b/R/vect_link.R
@@ -6,7 +6,7 @@ readVECT <- function(vname, layer, type=NULL, plugin=NULL,
         with_prj=TRUE,  with_c=FALSE, mapset=NULL, pointDropZ=FALSE,
         driver=NULL) {
         .Deprecated(new="read_VECT", package="rgrass7", old="readVECT",
-            msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
+            msg="Package rgrass7 transitioning to package rgrass for GRASS 8.\n'readVECT' is deprecated. Use 'read_VECT' instead.")
         if (is.null(.get_R_interface())) 
        stop("use either use_sp() or use_sf() at session start to choose\n sp or sf/stars classes")
         R_in_sp <- isTRUE(.get_R_interface() == "sp")
@@ -393,7 +393,7 @@ writeVECT <- function(SDF, vname, #factor2char = TRUE,
     driver=NULL, min_area=0.0001, snap=-1) {
 
     .Deprecated(new="write_VECT", package="rgrass7", old="writeVECT",
-       msg="Package rgrass7 transitioning to package rgrass for GRASS 8")
+       msg="Package rgrass7 transitioning to package rgrass for GRASS 8.\n'writeVECT is deprecated. Use 'write_VECT' instead.")
     R_in_sp <- isTRUE(.get_R_interface() == "sp")
 
     if (is.null(ignore.stderr))

--- a/R/vect_link_ng.R
+++ b/R/vect_link_ng.R
@@ -1,0 +1,63 @@
+# Interpreted GRASS 7, 8 interface functions
+# Copyright (c) 2022 Roger S. Bivand
+#
+read_VECT <- function(vname, layer, type=NULL, flags="overwrite",
+    ignore.stderr = NULL) {
+    if (!(requireNamespace("terra", quietly=TRUE))) 
+        stop("terra required for SpatVector output")
+    if (is.null(ignore.stderr))
+        ignore.stderr <- get.ignore.stderrOption()
+    stopifnot(is.logical(ignore.stderr))
+    if (missing(layer)) layer <- "1"
+    layer <- as.character(layer)
+    if (get.suppressEchoCmdInFuncOption()) {
+        inEchoCmd <- set.echoCmdOption(FALSE)
+    }
+    vinfo <- vInfo(vname)
+    types <- names(vinfo)[which(vinfo > 0)]
+    if (is.null(type)) {
+        if (length(grep("points", types)) > 0) type <- "point"
+        if (length(grep("lines", types)) > 0) type <- "line"
+        if (length(grep("areas", types)) > 0) type <- "area"
+        if (is.null(type)) stop("Vector type not found")
+    }
+    tf <- tempfile(fileext=".gpkg")
+    execGRASS("v.out.ogr", flags=flags, input=vname, type=type,
+        layer=as.character(layer), output=tf, output_layer=vname,
+        format="GPKG", ignore.stderr=ignore.stderr)
+    res <- getMethod("vect", "character")(tf)
+    if (!all(getMethod("is.valid", "SpatVector")(res))) 
+        res <- getMethod("makeValid", "SpatVector")(res)
+    if (get.suppressEchoCmdInFuncOption()) {
+        tull <- set.echoCmdOption(inEchoCmd)
+    }
+    res
+}
+
+write_VECT <- function(x, vname, flags="overwrite", ignore.stderr = NULL) {
+
+    if (!(requireNamespace("terra", quietly=TRUE))) 
+        stop("terra required for SpatVector input")
+    if (is.null(ignore.stderr))
+            ignore.stderr <- get.ignore.stderrOption()
+    stopifnot(is.logical(ignore.stderr))
+    if (get.suppressEchoCmdInFuncOption()) {
+        inEchoCmd <- set.echoCmdOption(FALSE)
+    }
+    type <- NULL
+    if (getMethod("geomtype", "SpatVector")(x) == "points") type <- "point"
+    if (getMethod("geomtype", "SpatVector")(x) == "lines") type <- "line"
+    if (getMethod("geomtype", "SpatVector")(x) == "polygons") type <- "boundary"
+    if (is.null(type)) stop("Unknown data class")
+
+    tf <- tempfile(fileext=".gpkg")
+    getMethod("writeVector", c("SpatVector", "character"))(x, filename=tf,
+        filetype="GPKG", overwrite=TRUE)
+                    
+    execGRASS("v.in.ogr", flags=flags, input=tf, output=vname, type=type,
+        ignore.stderr=ignore.stderr)
+    if (get.suppressEchoCmdInFuncOption()) 
+        tull <- set.echoCmdOption(inEchoCmd)
+}
+
+

--- a/R/xml1.R
+++ b/R/xml1.R
@@ -19,7 +19,7 @@ parseGRASS <- function(cmd, legacyExec=NULL) {
                 t0 <- try(sub(".bat", "", 
                    list.files(paste(Sys.getenv("GRASS_ADDON_BASE"),
                        "bin", sep="/"), pattern=".bat$")), silent=TRUE)
-                if (length(t0) > 0 && class(t0) != "try-error" &&
+                if (length(t0) > 0 && !inherits(t0, "try-error") &&
                    is.character(t0) && nchar(t0) > 0)
                    WN_bat <- c(WN_bat, t0)
             }
@@ -33,7 +33,7 @@ parseGRASS <- function(cmd, legacyExec=NULL) {
         cmd0 <- paste(paste(prep, cmd, ext, sep=""), "--interface-description")
         if (legacyExec) {
             tr <- try(system(cmd0, intern=TRUE))
-	    if (class(tr) == "try-error") stop(paste(cmd, "not found"))
+	    if (inherits(tr, "try-error")) stop(paste(cmd, "not found"))
         } else {
             errFile <- tempfile()
             outFile <- tempfile()

--- a/R/xml1.R
+++ b/R/xml1.R
@@ -11,7 +11,8 @@ parseGRASS <- function(cmd, legacyExec=NULL) {
     if (is.null(res)) {
         ext <- get("addEXE", envir=.GRASS_CACHE)
         WN_bat <- get("WN_bat", envir=.GRASS_CACHE)
-        if (get("SYS", envir=.GRASS_CACHE) == "WinNat" && nchar(WN_bat) == 0) {
+        if (get("SYS", envir=.GRASS_CACHE) == "WinNat" &&
+            (length(WN_bat) == 1L && nchar(WN_bat) == 0)) {
             WN_bat <- sub(".bat", "", 
                 list.files(paste(Sys.getenv("GISBASE"), "bin", sep="/"),
                 pattern=".bat$"))
@@ -20,7 +21,7 @@ parseGRASS <- function(cmd, legacyExec=NULL) {
                    list.files(paste(Sys.getenv("GRASS_ADDON_BASE"),
                        "bin", sep="/"), pattern=".bat$")), silent=TRUE)
                 if (length(t0) > 0 && !inherits(t0, "try-error") &&
-                   is.character(t0) && nchar(t0) > 0)
+                   is.character(t0) && all(nchar(t0) > 0))
                    WN_bat <- c(WN_bat, t0)
             }
             assign("WN_bat", WN_bat, envir=.GRASS_CACHE)

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+2022-02-18: rastNG branch ready for testing and within a short period for merging with the rgrass7 and rgrass branches and main.
+
 2021-12-14: repository re-named "rgrass" to prepare for the release of GRASS 8.0.
 
 Interpreted interface between GRASS geographical information system and R, based on starting R from within the GRASS GIS environment, or running free-standing R in a temporary GRASS location; the package provides facilities for using all GRASS commands from the R command line.

--- a/man/initGRASS.Rd
+++ b/man/initGRASS.Rd
@@ -66,6 +66,12 @@ write_RAST(r, "elev", flags="overwrite")
 execGRASS("r.info", map="elev")
 }
 if (run) {
+s <- rast(r)
+values(s) <- values(r)
+write_RAST(s, "elev1", flags="overwrite")
+execGRASS("r.info", map="elev1")
+}
+if (run) {
 execGRASS("r.slope.aspect", flags="overwrite", elevation="elev", slope="slope", aspect="aspect")
 }
 if (run) {

--- a/man/initGRASS.Rd
+++ b/man/initGRASS.Rd
@@ -49,9 +49,28 @@ remove_GISRC()
 
 \seealso{\code{\link{gmeta}}}
 \examples{
-\dontrun{
-initGRASS("/usr/bin/grass-7.0.0", home=tempdir())
-initGRASS("C:/GRASS", home=tempdir())
+GRASS_INSTALLATION <- Sys.getenv("GRASS_INSTALLATION")
+run <- FALSE
+if (nzchar(GRASS_INSTALLATION)) run <- file.info(GRASS_INSTALLATION)$isdir
+run <- require(terra, quietly=TRUE)
+if (run) {
+f <- system.file("ex/elev.tif", package="terra")
+r <- rast(f)
+plot(r, col=grDevices::terrain.colors(50))
+}
+if (run) {
+(loc <- initGRASS(GRASS_INSTALLATION, home=tempdir(), SG=r, override=TRUE))
+}
+if (run) {
+write_RAST(r, "elev", flags="overwrite")
+execGRASS("r.info", map="elev")
+}
+if (run) {
+execGRASS("r.slope.aspect", flags="overwrite", elevation="elev", slope="slope", aspect="aspect")
+}
+if (run) {
+u1 <- read_RAST(c("elev", "slope", "aspect"), return_format="terra")
+plot(u1[["elev"]], col=grDevices::terrain.colors(50))
 }
 }
 % Add one or more standard keywords, see file 'KEYWORDS' in the

--- a/man/initGRASS.Rd
+++ b/man/initGRASS.Rd
@@ -52,7 +52,7 @@ remove_GISRC()
 GRASS_INSTALLATION <- Sys.getenv("GRASS_INSTALLATION")
 run <- FALSE
 if (nzchar(GRASS_INSTALLATION)) run <- file.info(GRASS_INSTALLATION)$isdir
-run <- require(terra, quietly=TRUE)
+run <- run && require(terra, quietly=TRUE)
 if (run) {
 f <- system.file("ex/elev.tif", package="terra")
 r <- rast(f)

--- a/man/readRAST.Rd
+++ b/man/readRAST.Rd
@@ -22,7 +22,7 @@ writeRAST(x, vname, zcol = 1, NODATA=NULL,
  ignore.stderr = get.ignore.stderrOption(), useGDAL=get.useGDALOption(),
  overwrite=FALSE, flags=NULL, drivername="GTiff")
 write_RAST(x, vname, zcol = 1, NODATA=NULL, flags=NULL, 
- ignore.stderr = get.ignore.stderrOption(), overwrite=FALSE)
+ ignore.stderr = get.ignore.stderrOption(), overwrite=FALSE, verbose=TRUE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -43,6 +43,7 @@ write_RAST(x, vname, zcol = 1, NODATA=NULL, flags=NULL,
   \item{NODATA}{by default NULL, in which case it is set to one less than \code{floor()}of the data values, otherwise an integer NODATA value (required to be integer by GRASS r.out.bin)}
   \item{overwrite}{default FALSE, if TRUE inserts \code{"overwrite"} into the value of the \code{flags} argument if not already there to allow existing GRASS rasters to be overwritten}
   \item{flags}{default NULL, character vector, for example \code{"overwrite"}}
+  \item{verbose}{default TRUE, report how writing to GRASS is specified}
 %  \item{colname}{alternative name for data column if not file basename}
 %  \item{integer}{logical value: TRUE if the input data is integer}
 }
@@ -148,6 +149,7 @@ run <- run && require("terra", quietly=TRUE)
 if (run) {
   v1 <- read_RAST("landuse", cat=TRUE, return_format="terra")
   v1
+  inMemory(v1)
 }
 if (run) {
   write_RAST(v1, "landuse1", flags=c("o", "overwrite"))

--- a/man/readRAST.Rd
+++ b/man/readRAST.Rd
@@ -1,10 +1,12 @@
-% Copyright (C) 2005-2015 Roger S. Bivand
+% Copyright (C) 2005-2022 Roger S. Bivand
 \name{readRAST}
 \alias{readRAST}
 \alias{writeRAST}
+\alias{read_RAST}
+\alias{write_RAST}
 \title{Read and write GRASS raster files}
 \description{
-Read GRASS raster files from GRASS into R SpatialGridDataFrame objects, and write single columns of R SpatialGridDataFrame objects to GRASS. \code{readRAST} and \code{writeRAST} use temporary binary files and r.out.bin and r.in.bin for speed reasons. 
+Read GRASS raster files from GRASS into R \pkg{sp} \code{"SpatialGridDataFrame"} or \pkg{terra} \code{"SpatRaster"} objects, and write single columns of \pkg{sp} \code{"SpatialGridDataFrame"} or \pkg{terra} \code{"SpatRaster"} objects to GRASS. \code{readRAST} and \code{writeRAST} use temporary binary files and r.out.bin and r.in.bin for speed reasons. \code{read_RAST()} and \code{write_RAST()} use \code{"RRASTER"} files written and read by GDAL. 
 }
 
 
@@ -14,14 +16,19 @@ readRAST(vname, cat=NULL, ignore.stderr = get.ignore.stderrOption(),
  NODATA=NULL, plugin=get.pluginOption(), mapset=NULL,
  useGDAL=get.useGDALOption(), close_OK=TRUE, drivername="GTiff",
  driverFileExt=NULL, return_SGDF=TRUE)
+read_RAST(vname, cat=NULL, NODATA=NULL, ignore.stderr=get.ignore.stderrOption(),
+ return_format="SGDF", close_OK=return_format=="SGDF", flags=NULL)
 writeRAST(x, vname, zcol = 1, NODATA=NULL,
  ignore.stderr = get.ignore.stderrOption(), useGDAL=get.useGDALOption(),
  overwrite=FALSE, flags=NULL, drivername="GTiff")
+write_RAST(x, vname, zcol = 1, NODATA=NULL, flags=NULL, 
+ ignore.stderr = get.ignore.stderrOption(), overwrite=FALSE)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{vname}{A vector of GRASS raster file names}
   \item{cat}{default NULL; if not NULL, must be a logical vector matching vname, stating which (CELL) rasters to return as factor}
+  \item{return_format}{For \code{read_RAST()}, either \code{"SGDF"} or \code{"terra"}}
   \item{ignore.stderr}{default taking the value set by \code{set.ignore.stderrOption}; can be set to TRUE to silence \code{system()} output to standard error; does not apply on Windows platforms}
   \item{plugin}{default taking the value set by \code{set.pluginOption};
     NULL does auto-detection, changes to FALSE if vname is longer than 1, and a sanity check will be run on raster and current region, and the function will revert to FALSE if mismatch is found; if TRUE, the plugin is available and the raster should be read in its original region and resolution; if the plugin is used, no further arguments other than mapset are respected}
@@ -31,7 +38,7 @@ writeRAST(x, vname, zcol = 1, NODATA=NULL,
   \item{drivername}{default \code{"GTiff"}; a valid GDAL writable driver name to define the file format for intermediate files}
   \item{driverFileExt}{default NULL; otherwise string value of required driver file name extension}
   \item{return_SGDF}{default TRUE returning a \code{SpatialGridDataFrame} object, if FALSE, return a list with a \code{GridTopology} object, a list of bands, and a proj4string; see example below}
-  \item{x}{A SpatialGridDataFrame object for export to GRASS as a raster layer}
+  \item{x}{A SpatialGridDataFrame object for export to GRASS as a raster layer, for \code{write_RAST()} a \pkg{terra} \code{"SpatRaster"} object}
   \item{zcol}{Attribute column number or name}
   \item{NODATA}{by default NULL, in which case it is set to one less than \code{floor()}of the data values, otherwise an integer NODATA value (required to be integer by GRASS r.out.bin)}
   \item{overwrite}{default FALSE, if TRUE inserts \code{"overwrite"} into the value of the \code{flags} argument if not already there to allow existing GRASS rasters to be overwritten}
@@ -136,6 +143,16 @@ if (run) {
 }
 if (run) {
   execGRASS("g.remove", flags="f", name="basins0", type="raster")
+}
+run <- run && require("terra", quietly=TRUE)
+if (run) {
+  v1 <- read_RAST("landuse", cat=TRUE, return_format="terra")
+  v1
+}
+if (run) {
+  write_RAST(v1, "landuse1", flags=c("o", "overwrite"))
+  execGRASS("r.stats", flags="c", input="landuse1")
+  execGRASS("g.remove", flags="f", name="landuse1", type="raster")
 }
   Sys.setenv("GRASS_VERBOSE"=GV)
   set.ignore.stderrOption(ois)

--- a/man/readVECT.Rd
+++ b/man/readVECT.Rd
@@ -1,8 +1,10 @@
-% Copyright (C) 2005-2010 Roger S. Bivand
+% Copyright (C) 2005-2022 Roger S. Bivand
 %
 \name{readVECT}
 \alias{readVECT}
 \alias{writeVECT}
+\alias{read_VECT}
+\alias{write_VECT}
 \alias{vInfo}
 \alias{vColumns}
 \alias{vDataCount}
@@ -10,16 +12,19 @@
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{Read and write GRASS vector object files}
 \description{
-  \code{readVECT} moves one GRASS vector object file with attribute data through a temporary shapefile to a Spatial*DataFrame object of type determined by the GRASS vector object; \code{writeVECT} moves a Spatial*DataFrame object through a temporary shapefile to a GRASS vector object file. \code{vect2neigh} returns neighbour pairs with shared boundary length as described by Markus Neteler, in \url{https://stat.ethz.ch/pipermail/r-sig-geo/2005-October/000616.html}. \code{cygwin_clean_temp} can be called to try to clean the GRASS mapset-specific temporary directory under cygwin.
+  \code{readVECT} moves one GRASS vector object file with attribute data through a temporary shapefile to a Spatial*DataFrame object of type determined by the GRASS vector object; \code{writeVECT} moves a Spatial*DataFrame object through a temporary shapefile to a GRASS vector object file. \code{read_VECT} moves one GRASS vector object file with attribute data through a temporary GeoPackage file to a \pkg{terra} \code{"SpatVector"} object; \code{write_VECT} moves a \pkg{terra} \code{"SpatVector"} object through a temporary GeoPackage file to a GRASS vector object file. \code{vect2neigh} returns neighbour pairs with shared boundary length as described by Markus Neteler, in \url{https://stat.ethz.ch/pipermail/r-sig-geo/2005-October/000616.html}. \code{cygwin_clean_temp} can be called to try to clean the GRASS mapset-specific temporary directory under cygwin.
 }
 \usage{
 readVECT(vname, layer, type=NULL, plugin=NULL,
  remove.duplicates = TRUE, ignore.stderr=NULL,
  with_prj=TRUE, with_c=FALSE, mapset=NULL,
  pointDropZ=FALSE, driver=NULL)
+read_VECT(vname, layer, type=NULL, flags="overwrite",
+    ignore.stderr = NULL)
 writeVECT(SDF, vname,  v.in.ogr_flags=NULL,
  ignore.stderr = NULL, driver=NULL,
  min_area=0.0001, snap=-1)
+write_VECT(x, vname, flags="overwrite", ignore.stderr = NULL)
 vInfo(vname, layer, ignore.stderr = NULL)
 vColumns(vname, layer, ignore.stderr = NULL)
 vDataCount(vname, layer, ignore.stderr = NULL)
@@ -43,7 +48,8 @@ vect2neigh(vname, ID=NULL, ignore.stderr = NULL, remove=TRUE, vname2=NULL,
   \item{min_area}{default 0.0001); Minimum size of area to be imported (square meters) Smaller areas and islands are ignored. Should be greater than snap^2}
   \item{snap}{default -1); Snapping threshold for boundaries (map units). '-1' for no snap}
   \item{SDF}{A Spatial*DataFrame to be moved to GRASS as a vector object, for SpatialPointsDataFrame, SpatialLinesDataFrame, and SpatialPolygonsDataFrame objects, or an equivalent \code{"sf"} object}
-  \item{v.in.ogr_flags}{Character vector containing additional optional flags and/or options for v.in.ogr, particularly "o" and "overwrite"}
+  \item{x}{A \code{"SpatVector"} object moved to GRASS}
+  \item{flags, v.in.ogr_flags}{Character vector containing additional optional flags and/or options for v.in.ogr, particularly "o" and "overwrite"}
   \item{ID}{A valid DB column name for unique identifiers (optional)}
   \item{remove}{default TRUE, remove copied vectors created in \code{vect2neigh}}
   \item{vname2}{If on a previous run, remove was FALSE, the name of the temporary vector may be given to circumvent its generation}
@@ -148,6 +154,15 @@ if (run) {
 if (run) {
   nschs <- readVECT("newsch")
   print(summary(nschs))
+}
+run <- run && require("terra", quietly=TRUE)
+if (run) {
+  v1 <- rgrass7:::read_VECT("census")
+  v1
+}
+if (run) {
+  rgrass7:::write_VECT(v1, "census_sV")
+  execGRASS("v.info", map="census_sV")
 }
 Sys.setenv("GRASS_VERBOSE"=GV)
 set.ignore.stderrOption(ois)


### PR DESCRIPTION
The `rastNG` branch provides re-implementations using the `"SpatRaster"` and `"SpatVector"` classes from **terra**, and using **terra** methods for reading and writing intermediate files (See #42). The additions need checking on (`R CMD check rgrass7_0.2-8.tar.gz` in `nc_basic_spm_grass7` location):
[rgrass7_0.2-8.tar.gz](https://github.com/rsbivand/rgrass/files/8104472/rgrass7_0.2-8.tar.gz)
or this example file: 
[rgrass7-Ex.zip](https://github.com/rsbivand/rgrass/files/8104541/rgrass7-Ex.zip)


- [x] Windows standalone GRASS 8.0 binary R 4.1.2
- [x] Windows OSGeo4W GRASS 8.0 binary R 4.1.2
- [x] macOS x86_64 GRASS 8.0 binary (via Rosetta on M1) R 4.1.2
- [ ] macOS arm64 (arm64 GRASS not available)
- [x] Windows standalone GRASS 7.8 binary R 4.1.2
- [x] Windows OSGeo4W GRASS 7.8 binary R 4.1.2
- [x] macOS x86_64 GRASS 7.8 binary (via Rosetta on M1) R 4.1.2
- [x] Fedora GRASS 8.0 R 4.1.2
- [x] Fedora GRASS 7.8 R 4.1.2
- [x] Fedora GRASS 8.0 R 4.2dev
- [x] Fedora GRASS 7.8 R 4.2dev

before merging (possibly other Linux versions if contributions are possible).