### PR TITLE
More vignette updates

### DIFF
--- a/vignettes/coerce.Rmd
+++ b/vignettes/coerce.Rmd
@@ -40,6 +40,8 @@ From GDAL 3.5.0, the `RRASTER` driver also supports WKT2_2019 CRS representation
 
 These changes mean that users transferring data between R and GRASS will need to coerce between **terra** classes `SpatVector` and `SpatRaster` and the class system of choice. In addition, `SpatRaster` is only read into memory from file when this is required, so requiring some care.
 
+## Loading and attaching packages
+
 This vignette is constructed conditioning on the availability of aforementioned R packages, i.e. if some were missing at the time of package building, some code blocks will not be displayed.
 
 Below setting, needed before loading **sp**, is to prevent **sp** from relying on **rgdal** or **rgeos**.

--- a/vignettes/coerce.Rmd
+++ b/vignettes/coerce.Rmd
@@ -42,6 +42,9 @@ These changes mean that users transferring data between R and GRASS will need to
 
 This vignette is constructed conditioning on the availability of aforementioned R packages, i.e. if some were missing at the time of package building, some code blocks will not be displayed.
 
+Below setting, needed before loading **sp**, is to prevent **sp** from relying on **rgdal** or **rgeos**.
+Those packages will retire by the end of 2023 [@pebesma_r-spatial_2022].
+
 ```{r}
 Sys.setenv("_SP_EVOLUTION_STATUS_"="2")
 ```

--- a/vignettes/coerce.Rmd
+++ b/vignettes/coerce.Rmd
@@ -40,18 +40,40 @@ From GDAL 3.5.0, the `RRASTER` driver also supports WKT2_2019 CRS representation
 
 These changes mean that users transferring data between R and GRASS will need to coerce between **terra** classes `SpatVector` and `SpatRaster` and the class system of choice. In addition, `SpatRaster` is only read into memory from file when this is required, so requiring some care.
 
-On loading and attaching, **terra** displays its version:
+This vignette is constructed conditioning on the availability of aforementioned R packages, i.e. if some were missing at the time of package building, some code blocks will not be displayed.
 
-```{r}
-terra_available <- require("terra", quietly=TRUE)
-sf_available <- require("sf", quietly=TRUE)
-Sys.setenv("_SP_EVOLUTION_STATUS_"="2")
-sp_available <- require("sp", quietly=TRUE)
-stars_available <- require("stars", quietly=TRUE) && packageVersion("stars") > "0.5.4"
-raster_available <- require("raster", quietly=TRUE)
+```{r include=FALSE, message=FALSE}
+terra_available <- requireNamespace("terra", quietly=TRUE)
+sf_available <- requireNamespace("sf", quietly=TRUE)
+sp_available <- requireNamespace("sp", quietly=TRUE)
+stars_available <- requireNamespace("stars", quietly=TRUE) && packageVersion("stars") > "0.5.4"
+raster_available <- requireNamespace("raster", quietly=TRUE)
 ```
 
-This description is constructed conditioning on the availability of suggested packages. `terra::gdal()` tells us the versions of the external libraries being used by **terra**:
+On loading and attaching, **terra** displays its version:
+
+```{r, eval=terra_available}
+library("terra")
+```
+
+```{r, eval=sf_available}
+library("sf")
+```
+
+```{r, eval=sp_available}
+Sys.setenv("_SP_EVOLUTION_STATUS_"="2")
+library("sp")
+```
+
+```{r, eval=stars_available}
+library("stars")
+```
+
+```{r, eval=raster_available}
+library("raster")
+```
+
+`terra::gdal()` tells us the versions of the external libraries being used by **terra**:
 
 ```{r, eval=terra_available}
 gdal(lib="all")

--- a/vignettes/coerce.Rmd
+++ b/vignettes/coerce.Rmd
@@ -44,7 +44,7 @@ These changes mean that users transferring data between R and GRASS will need to
 
 This vignette is constructed conditioning on the availability of aforementioned R packages, i.e. if some were missing at the time of package building, some code blocks will not be displayed.
 
-Below setting, needed before loading **sp**, is to prevent **sp** from relying on **rgdal** or **rgeos**.
+The setting below, needed before loading **sp**, is to prevent **sp** from relying on **rgdal** or **rgeos**.
 Those packages will retire by the end of 2023 [@pebesma_r-spatial_2022].
 
 ```{r}

--- a/vignettes/coerce.Rmd
+++ b/vignettes/coerce.Rmd
@@ -42,6 +42,10 @@ These changes mean that users transferring data between R and GRASS will need to
 
 This vignette is constructed conditioning on the availability of aforementioned R packages, i.e. if some were missing at the time of package building, some code blocks will not be displayed.
 
+```{r}
+Sys.setenv("_SP_EVOLUTION_STATUS_"="2")
+```
+
 ```{r include=FALSE, message=FALSE}
 terra_available <- requireNamespace("terra", quietly=TRUE)
 sf_available <- requireNamespace("sf", quietly=TRUE)
@@ -61,7 +65,6 @@ library("sf")
 ```
 
 ```{r, eval=sp_available}
-Sys.setenv("_SP_EVOLUTION_STATUS_"="2")
 library("sp")
 ```
 

--- a/vignettes/refs.bib
+++ b/vignettes/refs.bib
@@ -81,3 +81,11 @@
     note = {R package version 0.5-5},
     url = {https://CRAN.R-project.org/package=stars},
 }
+
+@online{pebesma_r-spatial_2022,
+  title = {{R-spatial} Evolution: Retirement of {rgdal}, {rgeos} and {maptools}},
+  author = {Pebesma, Edzer and Bivand, Roger},
+  date = {2022},
+  url = {https://r-spatial.org/r/2022/04/12/evolution.html},
+  urldate = {2022-11-10}
+}

--- a/vignettes/use.Rmd
+++ b/vignettes/use.Rmd
@@ -91,7 +91,7 @@ knitr::include_graphics("rstudio_in_GRASS.png")
 
 ## Starting GRASS inside R
 
-From **spgrass6** 0.6-3, it has also been possible to start a GRASS session from a running R session using the `initGRASS()` function. This is done by setting GRASS and environment variables from the R session (https://grass.osgeo.org/grass80/manuals/variables.html).
+From **spgrass6** 0.6-3, it has also been possible to start a GRASS session from a running R session using the `initGRASS()` function. This is done by setting GRASS and environment variables from the R session (https://grass.osgeo.org/grass-stable/manuals/variables.html).
 
 It may be useful to set an environmental variable to the value of `GISBASE`, as shown for example in the GRASS terminal console:
 
@@ -116,7 +116,7 @@ Loading required package: XML
 GRASS GIS interface loaded with GRASS version: (GRASS not running)
 ```
 
-Starting GRASS from R may use a temporary location, or may use an existing GRASS `LOCATION`.
+Starting GRASS from R may use a temporary or an existing GRASS `LOCATION`.
 
 ### Temporary GRASS location
 


### PR DESCRIPTION
- Applying the suggestions by @veroandreo in #68 (weren't yet accepted -> committed in that pull request).
- `coerce.Rmd`: since the vignette serves the educational purpose, 9563916 suggests to promote `library()` for loading and attaching the packages and hides the logic of checking the package existance from the user, using `requireNamespace()` there.