### PR TITLE
initGRASS(): relax the need for explicit gisBase and override=TRUE

### DIFF
--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -51,11 +51,12 @@ initGRASS <- function(gisBase = NULL, home, SG, gisDbase, addon_base, location,
                    envir = environment())
 
     if (nchar(get.GIS_LOCK()) > 0) {
-      if(!override)
+      if(!override){
         ask_override("A GIS_LOCK environment variable is present",
                      missing_override = missing(override),
                      envir = environment())
         unset.GIS_LOCK() # no error means user wants to override
+      }
       else unset.GIS_LOCK()
     }
 

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -55,6 +55,7 @@ initGRASS <- function(gisBase = NULL, home, SG, gisDbase, addon_base, location,
         ask_override("A GIS_LOCK environment variable is present",
                      missing_override = missing(override),
                      envir = environment())
+        unset.GIS_LOCK() # no error means user wants to override
       else unset.GIS_LOCK()
     }
 

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -44,7 +44,9 @@ initGRASS <- function(gisBase = NULL, home, SG, gisDbase, addon_base, location,
     ignore.stderr=get.ignore.stderrOption()) {
 
     if (nchar(Sys.getenv("GISRC")) > 0 && !override)
-      ask_override(paste("A GRASS location", Sys.getenv("GISRC"), "is already in use"),
+      ask_override(paste0("A GRASS location (defined by ",
+                          Sys.getenv("GISRC"),
+                          ") is already in use"),
                    missing_override = missing(override),
                    envir = environment())
 

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -91,7 +91,7 @@ initGRASS <- function(gisBase = NULL, home, SG, gisDbase, addon_base, location,
                "Either provide the gisBase argument or set a ",
                "GRASS_INSTALLATION environment variable to provide the ",
                "gisBase path",
-               .call = FALSE)
+               call. = FALSE)
         }
         )
         message("Taking gisBase value from `grass --config path` output: ",

--- a/vignettes/use.Rmd
+++ b/vignettes/use.Rmd
@@ -93,7 +93,7 @@ knitr::include_graphics("rstudio_in_GRASS.png")
 
 From **spgrass6** 0.6-3, it has also been possible to start a GRASS session from a running R session using the `initGRASS()` function. This is done by setting GRASS and environment variables from the R session (https://grass.osgeo.org/grass-stable/manuals/variables.html).
 
-It may be useful to set an environmental variable to the value of `GISBASE`, as shown for example in the GRASS terminal console:
+It may be useful to set an environment variable to the value of `GISBASE`, as shown for example in the GRASS terminal console:
 
 ```
 GRASS nc_basic_spm_grass7/rsb:github-rsb > echo $GISBASE
@@ -130,7 +130,7 @@ terra 1.6.0
 > f <- system.file("ex/elev.tif", package="terra")
 > r <- rast(f)
 ```
-The first argument to `initGRASS()` is `gisBase=`, which here we are passing the value of the environmental variable after checking that it is a directory. The second argument is where to write the `GISRC` file. The third is a template raster (here a `"SpatRaster"` object) from which to clone the temporary location size, position, resolution and projection:
+The first argument to `initGRASS()` is `gisBase=`, which here we are passing the value of the environment variable after checking that it is a directory. The second argument is where to write the `GISRC` file. The third is a template raster (here a `"SpatRaster"` object) from which to clone the temporary location size, position, resolution and projection:
 
 ```
 > GRASS_INSTALLATION <- Sys.getenv("GRASS_INSTALLATION")

--- a/vignettes/use.Rmd
+++ b/vignettes/use.Rmd
@@ -139,6 +139,10 @@ The first argument to `initGRASS()` is `gisBase=`, which here we are passing the
 > loc <- initGRASS(gisBase=GRASS_INSTALLATION, home=tempdir(), SG=r, override=TRUE)
 ```
 
+If the `gisBase` argument is missing, `initGRASS()` will do a minimal effort of guessing it.
+Firstly, if a `GRASS_INSTALLATION` environment variable is availabe, then its value will automatically be used for `gisBase`.
+If not, then the system command `grass --config path` will be tried to get the value of `GISBASE` that corresponds to the GRASS installation in the system PATH (if any).
+
 As can be seen, `initGRASS()` creates not only environment and GRASS variables, but also many files in the location mapsets; `g.gisenv` also shows details:
 
 ```


### PR DESCRIPTION
#### Using GRASS_INSTALLATION

The essential piece is bc68d50, which fixes #71: the value of an environment variable `GRASS_INSTALLATION`, if present, is used for `gisBase` if `gisBase` is not provided. This makes `initGRASS()` behave as documented on that matter. If no `GRASS_INSTALLATION` is present, then the fallback with `grass --config path` is tried which @Robinlovelace had put in place in #63 (now using `shell()` in case of Windows, which may actually work in a OSGeo4W shell; not tested). Corresponding messages have been added or tweaked.

This gives us:

```r
> initGRASS(override = TRUE)
No gisBase set. Trying to detect from the GRASS_INSTALLATION environment variable.
No GRASS_INSTALLATION environment variable was found.
Trying to set gisBase by running command `grass --config path` (requires grass in the system PATH).
Taking gisBase value from `grass --config path` output: /usr/lib/grass82
gisdbase    /tmp/RtmprC0NSo 
location    file35744eb85606 
mapset      file3574817ddd3 
rows        1 
columns     1 
north       1 
south       0 
west        0 
east        1 
nsres       1 
ewres       1 
Warning message:
In execGRASS("g.region", flags = c("g", "3"), intern = TRUE, ignore.stderr = ignore.stderr) :
  The command:
g.region -g -3
produced at least one warning during execution:
WARNING: <PROJ_INFO> file not found for location <file35744eb85606>
WARNING: <PROJ_UNITS> file not found for location <file35744eb85606>
> 
> Sys.setenv(GRASS_INSTALLATION="/usr/lib/grass82")
>
> initGRASS(override = TRUE)
No gisBase set. Trying to detect from the GRASS_INSTALLATION environment variable.
Taking gisBase value from GRASS_INSTALLATION: /usr/lib/grass82
gisdbase    /tmp/RtmprC0NSo 
location    file35746f90f466 
mapset      file3574224c3933 
rows        1 
columns     1 
north       1 
south       0 
west        0 
east        1 
nsres       1 
ewres       1 
Warning message:
In execGRASS("g.region", flags = c("g", "3"), intern = TRUE, ignore.stderr = ignore.stderr) :
  The command:
g.region -g -3
produced at least one warning during execution:
WARNING: <PROJ_INFO> file not found for location <file35746f90f466>
WARNING: <PROJ_UNITS> file not found for location <file35746f90f466>
```

This has also been documented in the `use.Rmd` vignette.

#### Behaviour when `GISRC` or `GIS_LOCK` are present

Secondly, this PR tries to make `initGRASS()` postpone the error if `GISRC` or `GIS_LOCK` are present, and when the user did not provide the `override` argument. These shell variables remain present after a first-time call to `initGRASS()` while still in the same shell (~ RStudio) session. The corresponding GISRC file may be more persistent across sessions.

77ba7ff: essentially, if `initGRASS()` is executed interactively and `override` is _missing_, then user will be _asked_  what (s)he wants, allowing to override. This may be debated, as nothing is wrong with current behaviour – throwing error if `override=FALSE` (the default) in such case – so this is only a matter of how the user is treated. I think that in almost all cases, the user will want to override but just forgot to do so. The dialog with the user will tell about `override=TRUE`, just like the error did. If explicitly passing `override=FALSE`, then nothing changes.

As a bonus, `initGRASS()` works out of the box without arguments in more cases, which is what @Robinlovelace was trying in https://github.com/rsbivand/rgrass/pull/63#issuecomment-1222541153. However, the user must interact and is taught to add `override=TRUE`.

This was just an idea that I got by reading https://github.com/rsbivand/rgrass/pull/63#issuecomment-1222541153, feel free to drop it.

```r
> initGRASS()
A GRASS location /home/floris/.grassrc8 is already in use.
Do you want to override ('no' will abort)? (y/n) y
Overriding. Avoid this question by setting override = TRUE
No gisBase set. Trying to detect from the GRASS_INSTALLATION environment variable.
Taking gisBase value from GRASS_INSTALLATION: /usr/lib/grass82
gisdbase    /tmp/RtmprC0NSo 
location    file3574cfdfa19 
mapset      file35742aae9377 
rows        1 
columns     1 
north       1 
south       0 
west        0 
east        1 
nsres       1 
ewres       1 
Warning message:
In execGRASS("g.region", flags = c("g", "3"), intern = TRUE, ignore.stderr = ignore.stderr) :
  The command:
g.region -g -3
produced at least one warning during execution:
WARNING: <PROJ_INFO> file not found for location <file3574cfdfa19>
WARNING: <PROJ_UNITS> file not found for location <file3574cfdfa19>
> 
> initGRASS()
A GRASS location /home/floris/.grassrc8 is already in use.
Do you want to override ('no' will abort)? (y/n) n
Error: Aborting. To override, set override = TRUE
> 
> initGRASS(override=FALSE)
Error: A GRASS location /home/floris/.grassrc8 is already in use; to override, set override = TRUE
```

