### PR TITLE
write_RAST: fix overwrite behavior for SpatRaster

### DIFF
--- a/R/rast_link.R
+++ b/R/rast_link.R
@@ -394,6 +394,8 @@ write_RAST <- function(x, vname, zcol = 1, NODATA=NULL, flags=NULL,
     stopifnot(is.character(vname))
     if (!is.null(flags)) stopifnot(is.character(flags))
 
+    if (overwrite && !("overwrite" %in% flags))
+        flags <- c(flags, "overwrite")
     if (inherits(x, "SpatialGridDataFrame")) {
         if (!(requireNamespace("sp", quietly=TRUE))) 
             stop("sp required for SGDF input")
@@ -412,8 +414,6 @@ write_RAST <- function(x, vname, zcol = 1, NODATA=NULL, flags=NULL,
         rtmpfl11 <- paste(rtmpfl1, fid, sep=.Platform$file.sep)
         if (!is.numeric(x@data[[zcol]])) 
             stop("only numeric columns may be exported")
-        if (overwrite && !("overwrite" %in% flags))
-            flags <- c(flags, "overwrite")
         res <- writeBinGrid_ng(x, rtmpfl11, attr = zcol, na.value = NODATA)
                         
         flags <- c(res$flag, flags)


### PR DESCRIPTION
Currently, the `overwrite = TRUE` in `write_RAST` doesn't work when `SpatRaster` is used. This PR should fix that.

There are some inconsistencies between `write_RAST` and `write_VECT` API regarding overwriting:
```
write_VECT(x, vname, ..., flags="overwrite")
write_RAST(x, vname, ... , flags=NULL, overwrite=FALSE, verbose=TRUE)
```
so ideally this should be standardized.