### PR TITLE
Restyle code

### DIFF
--- a/R/AAA.R
+++ b/R/AAA.R
@@ -1,41 +1,42 @@
-.GRASS_CACHE <- new.env(FALSE, parent=globalenv())
+.GRASS_CACHE <- new.env(FALSE, parent = globalenv())
 
-if(!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
+if (!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
 
 .onLoad <- function(lib, pkg) {
-  assign(".GRASS_old.GRASS_PAGER", Sys.getenv("GRASS_PAGER"), envir=.GRASS_CACHE)
-  Sys.setenv("GRASS_PAGER"="cat")
+  assign(".GRASS_old.GRASS_PAGER", Sys.getenv("GRASS_PAGER"), envir = .GRASS_CACHE)
+  Sys.setenv("GRASS_PAGER" = "cat")
   assign(".GRASS_old.GRASS_MESSAGE_FORMAT", Sys.getenv("GRASS_MESSAGE_FORMAT"),
-    envir=.GRASS_CACHE)
-  assign("INIT_USED", FALSE, envir=.GRASS_CACHE)
-  assign("remove_GISRC", FALSE, envir=.GRASS_CACHE)
-  
-  Sys.setenv("GRASS_MESSAGE_FORMAT"="text")
+    envir = .GRASS_CACHE
+  )
+  assign("INIT_USED", FALSE, envir = .GRASS_CACHE)
+  assign("remove_GISRC", FALSE, envir = .GRASS_CACHE)
+
+  Sys.setenv("GRASS_MESSAGE_FORMAT" = "text")
 
   gisrc <- Sys.getenv("GISRC")
   loc <- Sys.getenv("LOCATION_NAME")
 
-  assign("cmdCACHE", list(), envir=.GRASS_CACHE)
-  assign("override_encoding", "", envir=.GRASS_CACHE)
+  assign("cmdCACHE", list(), envir = .GRASS_CACHE)
+  assign("override_encoding", "", envir = .GRASS_CACHE)
   SYS <- ""
   if (.Platform$OS.type == "windows") SYS <- "WinNat"
   else if (.Platform$OS.type == "unix") SYS <- "unix"
   else SYS <- "unknown"
-  assign("SYS", SYS, envir=.GRASS_CACHE)
+  assign("SYS", SYS, envir = .GRASS_CACHE)
   res <- ""
-  if (SYS == "WinNat") res =".exe"
-  assign("addEXE", res, envir=.GRASS_CACHE)
-  assign("WN_bat", "", envir=.GRASS_CACHE)
+  if (SYS == "WinNat") res = ".exe"
+  assign("addEXE", res, envir = .GRASS_CACHE)
+  assign("WN_bat", "", envir = .GRASS_CACHE)
 
-  assign("ignore.stderr", FALSE, envir=.GRASS_CACHE)
-  assign("stop_on_no_flags_paras", TRUE, envir=.GRASS_CACHE)
-  assign("echoCmd", FALSE, envir=.GRASS_CACHE)
-  assign("GV", "", envir=.GRASS_CACHE)
-  assign("useIntern", FALSE, envir=.GRASS_CACHE)
-  assign("legacyExec", .Platform$OS.type == "windows", envir=.GRASS_CACHE)
-  assign("defaultFlags", NULL, envir=.GRASS_CACHE)
-  assign("suppressEchoCmdInFunc", TRUE, envir=.GRASS_CACHE)
-  assign("R_interface", NULL, envir=.GRASS_CACHE)
+  assign("ignore.stderr", FALSE, envir = .GRASS_CACHE)
+  assign("stop_on_no_flags_paras", TRUE, envir = .GRASS_CACHE)
+  assign("echoCmd", FALSE, envir = .GRASS_CACHE)
+  assign("GV", "", envir = .GRASS_CACHE)
+  assign("useIntern", FALSE, envir = .GRASS_CACHE)
+  assign("legacyExec", .Platform$OS.type == "windows", envir = .GRASS_CACHE)
+  assign("defaultFlags", NULL, envir = .GRASS_CACHE)
+  assign("suppressEchoCmdInFunc", TRUE, envir = .GRASS_CACHE)
+  assign("R_interface", NULL, envir = .GRASS_CACHE)
 }
 
 .onAttach <- function(lib, pkg) {
@@ -45,36 +46,36 @@ if(!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
   else {
     gv <- .grassVersion()
     comp <- .compatibleGRASSVersion(gv)
-    if (!is.na(comp) && !comp ){
-        stop( attr(comp, "message") )
+    if (!is.na(comp) && !comp) {
+      stop(attr(comp, "message"))
     }
-    assign("GV", gv, envir=.GRASS_CACHE)
-    if(nchar(loc) == 0) {
-      loc <- read.dcf(gisrc)[1,"LOCATION_NAME"]
-  }
-
+    assign("GV", gv, envir = .GRASS_CACHE)
+    if (nchar(loc) == 0) {
+      loc <- read.dcf(gisrc)[1, "LOCATION_NAME"]
+    }
   }
 
   Smess <- paste('GRASS GIS interface loaded ',
     'with GRASS version: ', gv, '\n',
-    ifelse(nchar(loc) == 0, '', paste('and location: ', loc, '\n', sep="")),
-      sep="")
+    ifelse(nchar(loc) == 0, '', paste('and location: ', loc, '\n', sep = "")),
+    sep = ""
+  )
   packageStartupMessage(Smess, appendLF = FALSE)
 }
 
 .onUnload <- function(lib, pkg) {
-    if (get("INIT_USED", envir=.GRASS_CACHE)) {
-        if (get("remove_GISRC", envir=.GRASS_CACHE)) {
-            gisrc <- Sys.getenv("GISRC")
-            if (file.exists(gisrc)) unlink(gisrc)
-            Sys.unsetenv("GISRC")
-        }
-        unlink_.gislock()
-        unset.GIS_LOCK()
+  if (get("INIT_USED", envir = .GRASS_CACHE)) {
+    if (get("remove_GISRC", envir = .GRASS_CACHE)) {
+      gisrc <- Sys.getenv("GISRC")
+      if (file.exists(gisrc)) unlink(gisrc)
+      Sys.unsetenv("GISRC")
     }
-    Sys.setenv("GRASS_PAGER"=get(".GRASS_old.GRASS_PAGER", envir=.GRASS_CACHE))
-    Sys.setenv("GRASS_MESSAGE_FORMAT"=get(".GRASS_old.GRASS_MESSAGE_FORMAT",
-        envir=.GRASS_CACHE))
-    rm(.GRASS_CACHE)
+    unlink_.gislock()
+    unset.GIS_LOCK()
+  }
+  Sys.setenv("GRASS_PAGER" = get(".GRASS_old.GRASS_PAGER", envir = .GRASS_CACHE))
+  Sys.setenv("GRASS_MESSAGE_FORMAT" = get(".GRASS_old.GRASS_MESSAGE_FORMAT",
+    envir = .GRASS_CACHE
+  ))
+  rm(.GRASS_CACHE)
 }
-

--- a/R/AAA.R
+++ b/R/AAA.R
@@ -19,12 +19,16 @@ if (!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
   assign("cmdCACHE", list(), envir = .GRASS_CACHE)
   assign("override_encoding", "", envir = .GRASS_CACHE)
   SYS <- ""
-  if (.Platform$OS.type == "windows") SYS <- "WinNat"
-  else if (.Platform$OS.type == "unix") SYS <- "unix"
-  else SYS <- "unknown"
+  if (.Platform$OS.type == "windows") {
+    SYS <- "WinNat"
+  } else if (.Platform$OS.type == "unix") {
+    SYS <- "unix"
+  } else {
+    SYS <- "unknown"
+  }
   assign("SYS", SYS, envir = .GRASS_CACHE)
   res <- ""
-  if (SYS == "WinNat") res = ".exe"
+  if (SYS == "WinNat") res <- ".exe"
   assign("addEXE", res, envir = .GRASS_CACHE)
   assign("WN_bat", "", envir = .GRASS_CACHE)
 
@@ -42,8 +46,9 @@ if (!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
 .onAttach <- function(lib, pkg) {
   gisrc <- Sys.getenv("GISRC")
   loc <- Sys.getenv("LOCATION_NAME")
-  if (nchar(gisrc) == 0) gv <- "(GRASS not running)"
-  else {
+  if (nchar(gisrc) == 0) {
+    gv <- "(GRASS not running)"
+  } else {
     gv <- .grassVersion()
     comp <- .compatibleGRASSVersion(gv)
     if (!is.na(comp) && !comp) {
@@ -55,9 +60,9 @@ if (!exists("Sys.setenv", envir = baseenv())) Sys.setenv <- Sys.putenv
     }
   }
 
-  Smess <- paste('GRASS GIS interface loaded ',
-    'with GRASS version: ', gv, '\n',
-    ifelse(nchar(loc) == 0, '', paste('and location: ', loc, '\n', sep = "")),
+  Smess <- paste("GRASS GIS interface loaded ",
+    "with GRASS version: ", gv, "\n",
+    ifelse(nchar(loc) == 0, "", paste("and location: ", loc, "\n", sep = "")),
     sep = ""
   )
   packageStartupMessage(Smess, appendLF = FALSE)

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -35,7 +35,9 @@ ask_override <- function(msg, missing_override, envir) {
     if (grepl("^[Yy]", a)) {
       assign("override", TRUE, envir = envir)
       message("Overriding. Avoid this question by setting override = TRUE")
-    } else stop("Aborting. To override, set override = TRUE", call. = FALSE)
+    } else {
+      stop("Aborting. To override, set override = TRUE", call. = FALSE)
+    }
   } else {
     stop(msg, "; to override, set override = TRUE", call. = FALSE)
   }
@@ -45,7 +47,7 @@ initGRASS <- function(
     gisBase = NULL, home, SG, gisDbase, addon_base, location,
     mapset, override = FALSE, use_g.dirseps.exe = TRUE, pid, remove_GISRC = FALSE,
     ignore.stderr = get.ignore.stderrOption()) {
-  if (nchar(Sys.getenv("GISRC")) > 0 && !override)
+  if (nchar(Sys.getenv("GISRC")) > 0 && !override) {
     ask_override(
       paste0(
         "A GRASS location (defined by ",
@@ -55,6 +57,7 @@ initGRASS <- function(
       missing_override = missing(override),
       envir = environment()
     )
+  }
 
   if (nchar(get.GIS_LOCK()) > 0) {
     if (!override) {
@@ -63,7 +66,9 @@ initGRASS <- function(
         envir = environment()
       )
       unset.GIS_LOCK() # no error means user wants to override
-    } else unset.GIS_LOCK()
+    } else {
+      unset.GIS_LOCK()
+    }
   }
 
   if (missing(pid)) pid <- round(runif(1, 1, 1000))
@@ -124,12 +129,14 @@ initGRASS <- function(
   if (!file.exists(gisBase)) stop(paste(gisBase, "not found"))
   if (!file.info(gisBase)$isdir[1]) stop(gisBase, " is not a directory")
   bin_is_dir <- file.info(file.path(gisBase, "bin"))$isdir[1]
-  if (is.na(bin_is_dir))
+  if (is.na(bin_is_dir)) {
     stop(gisBase, " does not contain bin, the directory with GRASS programs")
+  }
   if (!bin_is_dir) stop(gisBase, "/bin is not a directory")
   scripts_is_dir <- file.info(file.path(gisBase, "scripts"))$isdir[1]
-  if (is.na(scripts_is_dir))
+  if (is.na(scripts_is_dir)) {
     stop(gisBase, " does not contain scripts, the directory with GRASS scripts")
+  }
   if (!scripts_is_dir) stop(gisBase, "/scripts is not a directory")
 
 
@@ -143,11 +150,12 @@ initGRASS <- function(
     Sys.setenv(GISBASE = gisBase)
     if (missing(home)) home <- Sys.getenv("USERPROFILE")
     Sys.setenv(HOME = home)
-    if (missing(addon_base))
+    if (missing(addon_base)) {
       addon_base <- paste(Sys.getenv("APPDATA"),
         "/GRASS", gv, "/addons",
         sep = ""
       )
+    }
     addon_res <- file.exists(addon_base, paste(addon_base, "/bin", sep = ""))
     if (any(addon_res)) Sys.setenv("GRASS_ADDON_BASE" = addon_base)
     OSGEO4W_ROOT <- Sys.getenv("OSGEO4W_ROOT")
@@ -159,10 +167,12 @@ initGRASS <- function(
     } else {
       unistring <- toupper(gisBase)
       unistring <- gsub("\\\\", "/", unistring)
-      if (length(grep("OSGEO4W.*/APPS/GRASS", unistring)) > 0)
+      if (length(grep("OSGEO4W.*/APPS/GRASS", unistring)) > 0) {
         stop("NOTE: If using OSGeo4W GRASS, start R in the OSGeo4W shell,\nsee help(initGRASS) for further details")
-      if (length(grep("QGIS.*/APPS/GRASS", unistring)) > 0)
+      }
+      if (length(grep("QGIS.*/APPS/GRASS", unistring)) > 0) {
         stop("NOTE: If using Windows standalone QGIS GRASS, start R in the QGIS standalone\nOSGeo4W shell, see help(initGRASS) for further details")
+      }
       Sys.setenv(GRASS_PROJSHARE = paste(Sys.getenv("GISBASE"),
         "\\share\\proj",
         sep = ""
@@ -183,9 +193,11 @@ initGRASS <- function(
         Sys.getenv("PATH"),
         sep = ""
       ))
-      if (addon_res[2]) Sys.setenv(PATH = paste(Sys.getenv(
-        "GRASS_ADDON_BASE"
-      ), "\\bin;", Sys.getenv("PATH"), sep = ""))
+      if (addon_res[2]) {
+        Sys.setenv(PATH = paste(Sys.getenv(
+          "GRASS_ADDON_BASE"
+        ), "\\bin;", Sys.getenv("PATH"), sep = ""))
+      }
       # etc/Init.bat
       #            GRASS_addons <- Sys.getenv("GRASS_ADDON_PATH")
       #            if (GRASS_addons == "")
@@ -202,9 +214,11 @@ initGRASS <- function(
         GrPyPATH <- paste(Sys.getenv("GISBASE"), "/etc/python",
           sep = ""
         )
-        if (nchar(ePyPATH) > 0)
+        if (nchar(ePyPATH) > 0) {
           Sys.setenv(PYTHONPATH = paste(GrPyPATH, ePyPATH, sep = ";"))
-        else Sys.setenv(PYTHONPATH = GrPyPATH)
+        } else {
+          Sys.setenv(PYTHONPATH = GrPyPATH)
+        }
       }
       if (nchar(OSGEO4W_ROOT) > 0) {
         Sys.setenv("PYTHONHOME" = paste(OSGEO4W_ROOT, "apps/Python37", sep = "/"))
@@ -219,11 +233,12 @@ initGRASS <- function(
       #            assign("pyScripts", pyScripts, envir=.GRASS_CACHE)
     }
     Sys.setenv(GISRC = paste(Sys.getenv("HOME"), "\\.grassrc", gv, sep = ""))
-    if (file.exists(Sys.getenv("GISRC")) && !override)
+    if (file.exists(Sys.getenv("GISRC")) && !override) {
       ask_override(paste("A GISRC file", Sys.getenv("GISRC"), "already exists"),
         missing_override = missing(override),
         envir = environment()
       )
+    }
     fn_gisrc <- "junk"
     if (isTRUE(file.access(".", 2) == 0)) {
       Sys.setenv(GISRC = fn_gisrc)
@@ -261,8 +276,9 @@ initGRASS <- function(
     OSGEO4W_ROOT <- ""
     Sys.setenv(GISBASE = gisBase)
     if (missing(home)) home <- Sys.getenv("HOME")
-    if (missing(addon_base))
+    if (missing(addon_base)) {
       addon_base <- paste(Sys.getenv("HOME"), "/.grass", gv, "/addons", sep = "")
+    }
     addon_res <- file.exists(
       addon_base, paste(addon_base, "/bin", sep = ""),
       paste(addon_base, "/scripts", sep = "")
@@ -293,18 +309,21 @@ initGRASS <- function(
     # FIXME Sys.info()["sysname"] == "Darwin"
     Sys.setenv(GISRC = paste(home, "/.grassrc", gv, sep = ""))
     # FIXME
-    if (file.exists(Sys.getenv("GISRC")) && !override)
+    if (file.exists(Sys.getenv("GISRC")) && !override) {
       ask_override(paste("A GISRC file", Sys.getenv("GISRC"), "already exists"),
         missing_override = missing(override),
         envir = environment()
       )
+    }
     ePyPATH <- Sys.getenv("PYTHONPATH")
     if (length(grep(basename(Sys.getenv("GISBASE")), ePyPATH)) < 1 ||
       nchar(ePyPATH) == 0) {
       GrPyPATH <- paste(Sys.getenv("GISBASE"), "etc", "python", sep = "/")
-      if (nchar(ePyPATH) > 0)
+      if (nchar(ePyPATH) > 0) {
         Sys.setenv(PYTHONPATH = paste(GrPyPATH, ePyPATH, sep = ":"))
-      else Sys.setenv(PYTHONPATH = GrPyPATH)
+      } else {
+        Sys.setenv(PYTHONPATH = GrPyPATH)
+      }
     }
     if (!missing(gisDbase)) {
       if (!file.exists(gisDbase)) dir.create(gisDbase)
@@ -320,7 +339,9 @@ initGRASS <- function(
       file = Sys.getenv("GISRC"),
       append = TRUE
     )
-  } else stop(paste("Platform variant", SYS, "not supported"))
+  } else {
+    stop(paste("Platform variant", SYS, "not supported"))
+  }
   set.GIS_LOCK(pid)
   assign("INIT_USED", TRUE, envir = .GRASS_CACHE)
   assign("GIS_LOCK", pid, envir = .GRASS_CACHE)
@@ -332,11 +353,13 @@ initGRASS <- function(
   if (missing(location)) location <- basename(tempfile())
   loc_path <- paste(gisDbase, location, sep = "/")
   if (!file.exists(loc_path)) dir.create(loc_path)
-  if (!file.exists(paste(loc_path, "PERMANENT", sep = "/")))
+  if (!file.exists(paste(loc_path, "PERMANENT", sep = "/"))) {
     dir.create(paste(loc_path, "PERMANENT", sep = "/"))
+  }
   if (missing(mapset)) mapset <- basename(tempfile())
-  if (!file.exists(paste(loc_path, mapset, sep = "/")))
+  if (!file.exists(paste(loc_path, mapset, sep = "/"))) {
     dir.create(paste(loc_path, mapset, sep = "/"))
+  }
   system(paste(
     paste("g.gisenv", get("addEXE", envir = .GRASS_CACHE), sep = ""),
     shQuote(paste("set=GISDBASE", gisDbase, sep = "="))
@@ -375,14 +398,15 @@ initGRASS <- function(
         Sys.setenv("GRASS_PYTHON" = paste(OSGEO4W_ROOT, "bin/python.exe", sep = "/"))
       }
     } else {
-      if (strsplit(system(paste("g.version", get("addEXE", envir = .GRASS_CACHE), " -g ", sep = ""), intern = TRUE)[1], "=")[[1]][2] > "7.6.1")
+      if (strsplit(system(paste("g.version", get("addEXE", envir = .GRASS_CACHE), " -g ", sep = ""), intern = TRUE)[1], "=")[[1]][2] > "7.6.1") {
         Sys.setenv("GRASS_PYTHON" = paste("python3", get("addEXE",
           envir = .GRASS_CACHE
         ), sep = ""))
-      else
+      } else {
         Sys.setenv("GRASS_PYTHON" = paste("python", get("addEXE",
           envir = .GRASS_CACHE
         ), sep = ""))
+      }
     }
   }
 
@@ -394,15 +418,17 @@ initGRASS <- function(
     mSG <- !missing(SG)
     if (mSG) {
       if (inherits(SG, "SpatialGrid")) {
-        if (!requireNamespace("sp", quietly = TRUE))
+        if (!requireNamespace("sp", quietly = TRUE)) {
           stop("The sp package is required for the SG argument")
+        }
         bb <- sp::bbox(SG)
         gt <- sp::gridparameters(SG)
         wkt_SG <- sp::wkt(SG)
         lonlatSG <- !sp::is.projected(SG)
       } else if (inherits(SG, "SpatRaster")) {
-        if (!requireNamespace("terra", quietly = TRUE))
+        if (!requireNamespace("terra", quietly = TRUE)) {
           stop("The terra package is required for the SG argument")
+        }
         bb <- getMethod("ext", "SpatRaster")(SG)
         bb <- as.vector(bb)
         bb <- matrix(bb, 2, 2, byrow = TRUE)
@@ -484,11 +510,12 @@ initGRASS <- function(
         flags = "p", intern = TRUE,
         ignore.stderr = ignore.stderr
       )
-      if (MS != "PERMANENT")
+      if (MS != "PERMANENT") {
         execGRASS("g.mapset",
           mapset = "PERMANENT", flags = "quiet",
           ignore.stderr = ignore.stderr
         )
+      }
       tull <- execGRASS("g.proj",
         flags = "c", wkt = tf,
         ignore.stderr = ignore.stderr, intern = TRUE
@@ -498,11 +525,12 @@ initGRASS <- function(
         ignore.stderr = ignore.stderr
       )
       execGRASS("g.region", flags = "d", ignore.stderr = ignore.stderr)
-      if (MS != "PERMANENT")
+      if (MS != "PERMANENT") {
         execGRASS("g.mapset",
           mapset = mapset, flags = "quiet",
           ignore.stderr = ignore.stderr
         )
+      }
     }
   }
   gmeta(ignore.stderr = ignore.stderr)

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -3,31 +3,33 @@
 #
 # GIS_LOCK 110814 RSB, suggested by Brian Oney
 get.GIS_LOCK <- function() {
-    Sys.getenv("GIS_LOCK")
+  Sys.getenv("GIS_LOCK")
 }
 
 set.GIS_LOCK <- function(pid) {
-    if (missing(pid)) pid <- round(runif(1, 1, 1000))
-    pid <- as.integer(pid)
-    stopifnot(!is.na(pid))
-    Sys.setenv(GIS_LOCK=pid)
+  if (missing(pid)) pid <- round(runif(1, 1, 1000))
+  pid <- as.integer(pid)
+  stopifnot(!is.na(pid))
+  Sys.setenv(GIS_LOCK = pid)
 }
 
 unset.GIS_LOCK <- function() {
-    Sys.unsetenv("GIS_LOCK")
+  Sys.unsetenv("GIS_LOCK")
 }
 
 unlink_.gislock <- function() {
-    gl <- paste(Sys.getenv("GISDBASE"), Sys.getenv("LOCATION_NAME"),
-        Sys.getenv("MAPSET"), ".gislock", sep="/")
-    if (file.exists(gl)) unlink(gl)
+  gl <- paste(Sys.getenv("GISDBASE"), Sys.getenv("LOCATION_NAME"),
+    Sys.getenv("MAPSET"), ".gislock",
+    sep = "/"
+  )
+  if (file.exists(gl)) unlink(gl)
 }
 
 ask_override <- function(msg, missing_override, envir) {
   if (interactive() && missing_override) {
     message(msg, ".")
     a <- ""
-    while(!grepl("^[Yy]([Ee][Ss])?$|^[Nn]([Oo])?$", a)) {
+    while (!grepl("^[Yy]([Ee][Ss])?$|^[Nn]([Oo])?$", a)) {
       a <- readline("Do you want to override ('no' will abort)? (y/n) ")
     }
     if (grepl("^[Yy]", a)) {
@@ -39,385 +41,478 @@ ask_override <- function(msg, missing_override, envir) {
   }
 }
 
-initGRASS <- function(gisBase = NULL, home, SG, gisDbase, addon_base, location,
-    mapset, override=FALSE, use_g.dirseps.exe=TRUE, pid, remove_GISRC=FALSE,
-    ignore.stderr=get.ignore.stderrOption()) {
+initGRASS <- function(
+    gisBase = NULL, home, SG, gisDbase, addon_base, location,
+    mapset, override = FALSE, use_g.dirseps.exe = TRUE, pid, remove_GISRC = FALSE,
+    ignore.stderr = get.ignore.stderrOption()) {
+  if (nchar(Sys.getenv("GISRC")) > 0 && !override)
+    ask_override(
+      paste0(
+        "A GRASS location (defined by ",
+        Sys.getenv("GISRC"),
+        ") is already in use"
+      ),
+      missing_override = missing(override),
+      envir = environment()
+    )
 
-    if (nchar(Sys.getenv("GISRC")) > 0 && !override)
-      ask_override(paste0("A GRASS location (defined by ",
-                          Sys.getenv("GISRC"),
-                          ") is already in use"),
-                   missing_override = missing(override),
-                   envir = environment())
+  if (nchar(get.GIS_LOCK()) > 0) {
+    if (!override) {
+      ask_override("A GIS_LOCK environment variable is present",
+        missing_override = missing(override),
+        envir = environment()
+      )
+      unset.GIS_LOCK() # no error means user wants to override
+    } else unset.GIS_LOCK()
+  }
 
-    if (nchar(get.GIS_LOCK()) > 0) {
-      if(!override){
-        ask_override("A GIS_LOCK environment variable is present",
-                     missing_override = missing(override),
-                     envir = environment())
-        unset.GIS_LOCK() # no error means user wants to override
-      }
-      else unset.GIS_LOCK()
-    }
+  if (missing(pid)) pid <- round(runif(1, 1, 1000))
+  pid <- as.integer(pid)
+  stopifnot(!is.na(pid))
+  stopifnot(is.logical(override))
+  stopifnot(length(override) == 1)
+  stopifnot(is.logical(use_g.dirseps.exe))
+  stopifnot(length(use_g.dirseps.exe) == 1)
+  stopifnot(is.logical(remove_GISRC))
+  stopifnot(length(remove_GISRC) == 1)
 
-    if (missing(pid)) pid <- round(runif(1, 1, 1000))
-    pid <- as.integer(pid)
-    stopifnot(!is.na(pid))
-    stopifnot(is.logical(override))
-    stopifnot(length(override) == 1)
-    stopifnot(is.logical(use_g.dirseps.exe))
-    stopifnot(length(use_g.dirseps.exe) == 1)
-    stopifnot(is.logical(remove_GISRC))
-    stopifnot(length(remove_GISRC) == 1)
-
-    if (is.null(gisBase)) {
-      message("No gisBase set. Trying to detect from the GRASS_INSTALLATION ",
-              "environment variable.")
-      grass_installation <- Sys.getenv("GRASS_INSTALLATION")
-      stopifnot(is.character(grass_installation))
-      if (nchar(grass_installation) > 0) {
-        message("Taking gisBase value from GRASS_INSTALLATION: ",
-                grass_installation)
-        gisBase <- grass_installation
-      } else {
-        message("No GRASS_INSTALLATION environment variable was found.\n",
-                "Trying to set gisBase by running command ",
-                "`grass --config path` (requires grass in the system PATH).")
-        tryCatch({
+  if (is.null(gisBase)) {
+    message(
+      "No gisBase set. Trying to detect from the GRASS_INSTALLATION ",
+      "environment variable."
+    )
+    grass_installation <- Sys.getenv("GRASS_INSTALLATION")
+    stopifnot(is.character(grass_installation))
+    if (nchar(grass_installation) > 0) {
+      message(
+        "Taking gisBase value from GRASS_INSTALLATION: ",
+        grass_installation
+      )
+      gisBase <- grass_installation
+    } else {
+      message(
+        "No GRASS_INSTALLATION environment variable was found.\n",
+        "Trying to set gisBase by running command ",
+        "`grass --config path` (requires grass in the system PATH)."
+      )
+      tryCatch(
+        {
           gisBase <-
             if (.Platform$OS.type == "windows") {
               shell("grass --config path", intern = TRUE)
             } else {
               system("grass --config path", intern = TRUE)
             }
-        }, error = function(e) {
+        },
+        error = function(e) {
           stop("grass seems to be unavailable in the system PATH.\n",
-               "Either provide the gisBase argument or set a ",
-               "GRASS_INSTALLATION environment variable to provide the ",
-               "gisBase path",
-               call. = FALSE)
+            "Either provide the gisBase argument or set a ",
+            "GRASS_INSTALLATION environment variable to provide the ",
+            "gisBase path",
+            call. = FALSE
+          )
         }
+      )
+      message(
+        "Taking gisBase value from `grass --config path` output: ",
+        gisBase
+      )
+      stopifnot(length(gisBase) == 1L)
+    }
+  }
+
+  if (!file.exists(gisBase)) stop(paste(gisBase, "not found"))
+  if (!file.info(gisBase)$isdir[1]) stop(gisBase, " is not a directory")
+  bin_is_dir <- file.info(file.path(gisBase, "bin"))$isdir[1]
+  if (is.na(bin_is_dir))
+    stop(gisBase, " does not contain bin, the directory with GRASS programs")
+  if (!bin_is_dir) stop(gisBase, "/bin is not a directory")
+  scripts_is_dir <- file.info(file.path(gisBase, "scripts"))$isdir[1]
+  if (is.na(scripts_is_dir))
+    stop(gisBase, " does not contain scripts, the directory with GRASS scripts")
+  if (!scripts_is_dir) stop(gisBase, "/scripts is not a directory")
+
+
+
+  gv <- readLines(file.path(gisBase, "etc/VERSIONNUMBER"))
+  gv <- substring(gv, 1, 1)
+
+  SYS <- get("SYS", envir = .GRASS_CACHE)
+  if (SYS == "WinNat") {
+    # grass63.bat
+    Sys.setenv(GISBASE = gisBase)
+    if (missing(home)) home <- Sys.getenv("USERPROFILE")
+    Sys.setenv(HOME = home)
+    if (missing(addon_base))
+      addon_base <- paste(Sys.getenv("APPDATA"),
+        "/GRASS", gv, "/addons",
+        sep = ""
+      )
+    addon_res <- file.exists(addon_base, paste(addon_base, "/bin", sep = ""))
+    if (any(addon_res)) Sys.setenv("GRASS_ADDON_BASE" = addon_base)
+    OSGEO4W_ROOT <- Sys.getenv("OSGEO4W_ROOT")
+    if (nchar(OSGEO4W_ROOT) > 0) {
+      Sys.setenv(GRASS_PROJSHARE = paste(OSGEO4W_ROOT,
+        "\\share\\proj",
+        sep = ""
+      ))
+    } else {
+      unistring <- toupper(gisBase)
+      unistring <- gsub("\\\\", "/", unistring)
+      if (length(grep("OSGEO4W.*/APPS/GRASS", unistring)) > 0)
+        stop("NOTE: If using OSGeo4W GRASS, start R in the OSGeo4W shell,\nsee help(initGRASS) for further details")
+      if (length(grep("QGIS.*/APPS/GRASS", unistring)) > 0)
+        stop("NOTE: If using Windows standalone QGIS GRASS, start R in the QGIS standalone\nOSGeo4W shell, see help(initGRASS) for further details")
+      Sys.setenv(GRASS_PROJSHARE = paste(Sys.getenv("GISBASE"),
+        "\\share\\proj",
+        sep = ""
+      ))
+    }
+
+    Wpath <- Sys.getenv("PATH")
+    if (length(grep(basename(Sys.getenv("GISBASE")), Wpath)) < 1) {
+      Sys.setenv(PATH = paste(Sys.getenv("GISBASE"), "\\lib;",
+        Sys.getenv("PATH"),
+        sep = ""
+      ))
+      Sys.setenv(PATH = paste(Sys.getenv("GISBASE"), "\\bin;",
+        Sys.getenv("PATH"),
+        sep = ""
+      ))
+      Sys.setenv(PATH = paste(Sys.getenv("GISBASE"), "\\extrabin;",
+        Sys.getenv("PATH"),
+        sep = ""
+      ))
+      if (addon_res[2]) Sys.setenv(PATH = paste(Sys.getenv(
+        "GRASS_ADDON_BASE"
+      ), "\\bin;", Sys.getenv("PATH"), sep = ""))
+      # etc/Init.bat
+      #            GRASS_addons <- Sys.getenv("GRASS_ADDON_PATH")
+      #            if (GRASS_addons == "")
+      #                Sys.setenv(PATH=paste(Sys.getenv("WINGISBASE"), "\\bin;",
+      #                    Sys.getenv("WINGISBASE"), "\\lib;",
+      #                    Sys.getenv("PATH"), sep=""))
+      #            else
+      #                Sys.setenv(PATH=paste(Sys.getenv("WINGISBASE"), "\\bin;",
+      #                    Sys.getenv("WINGISBASE"), "\\lib;",
+      #                    GRASS_addons, ";", Sys.getenv("PATH"), sep=""))
+      ePyPATH <- Sys.getenv("PYTHONPATH")
+      if ((length(grep(basename(Sys.getenv("GISBASE")), ePyPATH)) < 1) ||
+        nchar(ePyPATH) == 0) {
+        GrPyPATH <- paste(Sys.getenv("GISBASE"), "/etc/python",
+          sep = ""
         )
-        message("Taking gisBase value from `grass --config path` output: ",
-                gisBase)
-        stopifnot(length(gisBase) == 1L)
+        if (nchar(ePyPATH) > 0)
+          Sys.setenv(PYTHONPATH = paste(GrPyPATH, ePyPATH, sep = ";"))
+        else Sys.setenv(PYTHONPATH = GrPyPATH)
       }
-    }
-
-    if (!file.exists(gisBase)) stop(paste(gisBase, "not found"))
-    if (!file.info(gisBase)$isdir[1]) stop(gisBase, " is not a directory")
-    bin_is_dir <- file.info(file.path(gisBase, "bin"))$isdir[1]
-    if (is.na(bin_is_dir))
-      stop(gisBase, " does not contain bin, the directory with GRASS programs")
-    if (!bin_is_dir) stop(gisBase, "/bin is not a directory")
-    scripts_is_dir <- file.info(file.path(gisBase, "scripts"))$isdir[1]
-    if (is.na(scripts_is_dir))
-      stop(gisBase, " does not contain scripts, the directory with GRASS scripts")
-    if (!scripts_is_dir) stop(gisBase, "/scripts is not a directory")
-
-
-
-    gv <- readLines(file.path(gisBase, "etc/VERSIONNUMBER"))
-    gv <- substring(gv, 1, 1)
-
-    SYS <- get("SYS", envir=.GRASS_CACHE)
-    if (SYS == "WinNat") {
-# grass63.bat
-        Sys.setenv(GISBASE=gisBase)
-        if (missing(home)) home <- Sys.getenv("USERPROFILE")
-        Sys.setenv(HOME=home)
-        if (missing(addon_base))
-            addon_base <- paste(Sys.getenv("APPDATA"),
-                "/GRASS", gv, "/addons", sep="")
-        addon_res <- file.exists(addon_base, paste(addon_base, "/bin", sep=""))
-        if (any(addon_res)) Sys.setenv("GRASS_ADDON_BASE"=addon_base)
-        OSGEO4W_ROOT <- Sys.getenv("OSGEO4W_ROOT")
-        if (nchar(OSGEO4W_ROOT) > 0) {
-            Sys.setenv(GRASS_PROJSHARE=paste(OSGEO4W_ROOT,
-                "\\share\\proj", sep=""))
-        } else {
-            unistring <- toupper(gisBase)
-            unistring <- gsub("\\\\", "/", unistring)
-            if (length(grep("OSGEO4W.*/APPS/GRASS", unistring)) > 0)
-                stop("NOTE: If using OSGeo4W GRASS, start R in the OSGeo4W shell,\nsee help(initGRASS) for further details")
-	    if (length(grep("QGIS.*/APPS/GRASS", unistring)) > 0)
-                stop("NOTE: If using Windows standalone QGIS GRASS, start R in the QGIS standalone\nOSGeo4W shell, see help(initGRASS) for further details")
-            Sys.setenv(GRASS_PROJSHARE=paste(Sys.getenv("GISBASE"),
-                "\\share\\proj", sep=""))
-        }
-
-        Wpath <- Sys.getenv("PATH")
-        if (length(grep(basename(Sys.getenv("GISBASE")), Wpath)) < 1) {
-            Sys.setenv(PATH=paste(Sys.getenv("GISBASE"), "\\lib;",
-                Sys.getenv("PATH"), sep=""))
-            Sys.setenv(PATH=paste(Sys.getenv("GISBASE"), "\\bin;",
-                Sys.getenv("PATH"), sep=""))
-            Sys.setenv(PATH=paste(Sys.getenv("GISBASE"), "\\extrabin;",
-                Sys.getenv("PATH"), sep=""))
-            if (addon_res[2]) Sys.setenv(PATH=paste(Sys.getenv(
-                "GRASS_ADDON_BASE"), "\\bin;", Sys.getenv("PATH"), sep=""))
-# etc/Init.bat
-#            GRASS_addons <- Sys.getenv("GRASS_ADDON_PATH")
-#            if (GRASS_addons == "")
-#                Sys.setenv(PATH=paste(Sys.getenv("WINGISBASE"), "\\bin;",
-#                    Sys.getenv("WINGISBASE"), "\\lib;",
-#                    Sys.getenv("PATH"), sep=""))
-#            else
-#                Sys.setenv(PATH=paste(Sys.getenv("WINGISBASE"), "\\bin;",
-#                    Sys.getenv("WINGISBASE"), "\\lib;",
-#                    GRASS_addons, ";", Sys.getenv("PATH"), sep=""))
-            ePyPATH <- Sys.getenv("PYTHONPATH")
-            if ((length(grep(basename(Sys.getenv("GISBASE")), ePyPATH)) < 1)
-                || nchar(ePyPATH) == 0) {
-                GrPyPATH <- paste(Sys.getenv("GISBASE"), "/etc/python",
-                    sep="")
-                if (nchar(ePyPATH) > 0)
-                    Sys.setenv(PYTHONPATH=paste(GrPyPATH, ePyPATH, sep=";"))
-                else Sys.setenv(PYTHONPATH=GrPyPATH)
-            }
-            if (nchar(OSGEO4W_ROOT) > 0) {
-              Sys.setenv("PYTHONHOME"=paste(OSGEO4W_ROOT, "apps/Python37", sep="/"))
-            } else {
-              G_B_files <- list.files(Sys.getenv("GISBASE"))
-              Python_dir <- G_B_files[grep("Python", G_B_files)]
-              if (length(Python_dir) > 0) Sys.setenv("PYTHONHOME"=paste(Sys.getenv("GISBASE"), Python_dir[1], sep="/"))
-            }
-#            pyScripts <- basename(list.files(paste(Sys.getenv("GISBASE"),
-#                "scripts", sep="/"), pattern="py$"))
-#            names(pyScripts) <- sub("\\.py", "", pyScripts)
-#            assign("pyScripts", pyScripts, envir=.GRASS_CACHE)
-        }
-        Sys.setenv(GISRC=paste(Sys.getenv("HOME"), "\\.grassrc", gv, sep=""))
-        if (file.exists(Sys.getenv("GISRC")) && !override)
-          ask_override(paste("A GISRC file", Sys.getenv("GISRC"), "already exists"),
-                       missing_override = missing(override),
-                       envir = environment())
-        fn_gisrc <- "junk"
-        if (isTRUE(file.access(".", 2) == 0)) {
-            Sys.setenv(GISRC=fn_gisrc)
-        } else {
-            warning("working directory not writable, using tempfile for GISRC")
-            Sys.setenv(GISRC=paste0(tempfile(), "_", fn_gisrc))
-        }
-        cat("GISDBASE:", getwd(), "\n", file=Sys.getenv("GISRC"))
-        cat("LOCATION_NAME: <UNKNOWN>", "\n", file=Sys.getenv("GISRC"),
-            append=TRUE)
-        cat("MAPSET: <UNKNOWN>", "\n", file=Sys.getenv("GISRC"),
-            append=TRUE)
-        gisrc <- ifelse (use_g.dirseps.exe, system(paste("g.dirseps.exe -g",
-            shQuote(Sys.getenv("GISRC"))), intern=TRUE),
-            Sys.getenv("GISRC"))
-        assign("addEXE", .addexe(), envir=.GRASS_CACHE)
-        Sys.setenv(GISRC=gisrc)
-        if (!missing(gisDbase)) {
-            if (!file.exists(gisDbase)) dir.create(gisDbase)
-        } else {
-            gisDbase <- tempdir()
-        }
-        gisDbase <- ifelse (use_g.dirseps.exe, system(paste("g.dirseps.exe -g",
-            shQuote(gisDbase)), intern=TRUE), gisDbase)
-    } else if (SYS == "unix") {
-        OSGEO4W_ROOT <- ""
-        Sys.setenv(GISBASE=gisBase)
-        if (missing(home)) home <- Sys.getenv("HOME")
-        if (missing(addon_base))
-            addon_base <- paste(Sys.getenv("HOME"), "/.grass", gv, "/addons", sep="")
-        addon_res <- file.exists(addon_base, paste(addon_base, "/bin", sep=""),
-            paste(addon_base, "/scripts", sep=""))
-        if (any(addon_res)) Sys.setenv("GRASS_ADDON_BASE"=addon_base)
-        ePATH <- Sys.getenv("PATH")
-        if (length(grep(basename(Sys.getenv("GISBASE")), ePATH)) < 1) {
-          Sys.setenv(PATH=paste(Sys.getenv("GISBASE"), "/bin:",
-          Sys.getenv("GISBASE"), "/scripts",
-          ifelse(addon_res[2],
-            paste(":", Sys.getenv("GRASS_ADDON_BASE"), "/bin", sep=""), ""),
-          ifelse(addon_res[3],
-            paste(":", Sys.getenv("GRASS_ADDON_BASE"), "/scripts", sep=""),
-            ""),
-          ifelse(nchar(ePATH) == 0, "", ":"), ePATH, sep=""))
-        }
-        eLDPATH <- Sys.getenv("LD_LIBRARY_PATH")
-        if (length(grep(basename(Sys.getenv("GISBASE")), eLDPATH)) < 1) {
-            Sys.setenv(LD_LIBRARY_PATH=paste(Sys.getenv("GISBASE"), "/lib:",
-            ifelse(nchar(eLDPATH) == 0, "", ":"), eLDPATH, sep=""))
-        }
-#FIXME Sys.info()["sysname"] == "Darwin"
-        Sys.setenv(GISRC=paste(home, "/.grassrc", gv, sep=""))
-#FIXME
-        if (file.exists(Sys.getenv("GISRC")) && !override)
-          ask_override(paste("A GISRC file", Sys.getenv("GISRC"), "already exists"),
-                       missing_override = missing(override),
-                       envir = environment())
-        ePyPATH <- Sys.getenv("PYTHONPATH")
-        if (length(grep(basename(Sys.getenv("GISBASE")), ePyPATH)) < 1
-            || nchar(ePyPATH) == 0) {
-            GrPyPATH <- paste(Sys.getenv("GISBASE"), "etc", "python", sep="/")
-            if (nchar(ePyPATH) > 0)
-                 Sys.setenv(PYTHONPATH=paste(GrPyPATH, ePyPATH, sep=":"))
-            else Sys.setenv(PYTHONPATH=GrPyPATH)
-        }
-        if (!missing(gisDbase)) {
-            if (!file.exists(gisDbase)) dir.create(gisDbase)
-        } else {
-            gisDbase <- tempdir()
-        }
-        cat("GISDBASE:", gisDbase, "\n", file=Sys.getenv("GISRC"))
-        cat("LOCATION_NAME: <UNKNOWN>", "\n", file=Sys.getenv("GISRC"),
-            append=TRUE)
-        cat("MAPSET: <UNKNOWN>", "\n", file=Sys.getenv("GISRC"),
-            append=TRUE)
-    } else stop(paste("Platform variant", SYS, "not supported"))
-    set.GIS_LOCK(pid)
-    assign("INIT_USED", TRUE, envir=.GRASS_CACHE)
-    assign("GIS_LOCK", pid, envir=.GRASS_CACHE)
-    if (remove_GISRC) assign("remove_GISRC", remove_GISRC, envir=.GRASS_CACHE)
-    system(paste(paste("g.gisenv", get("addEXE", envir=.GRASS_CACHE), sep=""),
-        shQuote(paste("set=GISDBASE=", gisDbase))))
-    if (missing(location)) location <- basename(tempfile())
-    loc_path <- paste(gisDbase, location, sep="/")
-    if (!file.exists(loc_path)) dir.create(loc_path)
-    if (!file.exists(paste(loc_path, "PERMANENT", sep="/")))
-        dir.create(paste(loc_path, "PERMANENT", sep="/"))
-    if (missing(mapset)) mapset <- basename(tempfile())
-    if (!file.exists(paste(loc_path, mapset, sep="/")))
-        dir.create(paste(loc_path, mapset, sep="/"))
-    system(paste(paste("g.gisenv", get("addEXE", envir=.GRASS_CACHE), sep=""),
-        shQuote(paste("set=GISDBASE", gisDbase, sep="="))))
-    system(paste(paste("g.gisenv", get("addEXE", envir=.GRASS_CACHE), sep=""),
-        shQuote(paste("set=LOCATION_NAME", location, sep="="))))
-    system(paste(paste("g.gisenv", get("addEXE", envir=.GRASS_CACHE), sep=""),
-        shQuote(paste("set=MAPSET", mapset, sep="="))))
-    system(paste(paste("g.gisenv", get("addEXE", envir=.GRASS_CACHE), sep=""),
-        shQuote("set=GRASS_GUI=text")))
-    Sys.setenv(GISBASE=gisBase)
-    Sys.setenv(GISDBASE=gisDbase)
-    Sys.setenv(LOCATION_NAME=location)
-    Sys.setenv(MAPSET=mapset)
-    gv <- system(paste("g.version", get("addEXE", envir=.GRASS_CACHE),
-                       sep=""),  intern=TRUE)
-
-
-    comp <- .compatibleGRASSVersion(gv)
-    if ( !comp ){
-        stop( attr(comp, "message") )
-    }
-    grass_python <- Sys.getenv("GRASS_PYTHON")
-    if (grass_python == "") {
       if (nchar(OSGEO4W_ROOT) > 0) {
-        if (file.exists(paste(OSGEO4W_ROOT, "bin/python3.exe", sep="/"))) {
-          Sys.setenv("GRASS_PYTHON"=paste(OSGEO4W_ROOT, "bin/python3.exe", sep="/"))
-        } else {
-          Sys.setenv("GRASS_PYTHON"=paste(OSGEO4W_ROOT, "bin/python.exe", sep="/"))
-        }
+        Sys.setenv("PYTHONHOME" = paste(OSGEO4W_ROOT, "apps/Python37", sep = "/"))
       } else {
-        if (strsplit(system(paste("g.version", get("addEXE", envir=.GRASS_CACHE), " -g ", sep=""), intern=TRUE)[1], "=")[[1]][2] > "7.6.1")
-            Sys.setenv("GRASS_PYTHON"=paste("python3", get("addEXE",
-                envir=.GRASS_CACHE), sep=""))
-        else
-            Sys.setenv("GRASS_PYTHON"=paste("python", get("addEXE",
-                envir=.GRASS_CACHE), sep=""))
+        G_B_files <- list.files(Sys.getenv("GISBASE"))
+        Python_dir <- G_B_files[grep("Python", G_B_files)]
+        if (length(Python_dir) > 0) Sys.setenv("PYTHONHOME" = paste(Sys.getenv("GISBASE"), Python_dir[1], sep = "/"))
       }
+      #            pyScripts <- basename(list.files(paste(Sys.getenv("GISBASE"),
+      #                "scripts", sep="/"), pattern="py$"))
+      #            names(pyScripts) <- sub("\\.py", "", pyScripts)
+      #            assign("pyScripts", pyScripts, envir=.GRASS_CACHE)
     }
-
-    assign("GV", gv, envir=.GRASS_CACHE)
-    pfile <- paste(loc_path, "PERMANENT", "DEFAULT_WIND", sep="/")
-    mSG <- FALSE
-    if (!file.exists(pfile)) {
-        lonlat <- FALSE
-        mSG <- !missing(SG)
-        if (mSG) {
-            if (inherits(SG, "SpatialGrid")) {
-                if (!requireNamespace("sp", quietly=TRUE))
-                    stop("The sp package is required for the SG argument")
-                bb <- sp::bbox(SG)
-                gt <- sp::gridparameters(SG)
-                wkt_SG <- sp::wkt(SG)
-                lonlatSG <- !sp::is.projected(SG)
-            } else if (inherits(SG, "SpatRaster")) {
-                if (!requireNamespace("terra", quietly=TRUE))
-                    stop("The terra package is required for the SG argument")
-                bb <- getMethod("ext", "SpatRaster")(SG)
-				bb <- as.vector(bb)
-                bb <- matrix(bb, 2, 2, byrow=TRUE)
-                colnames(bb) <- c("min", "max")
-                cs <- getMethod("res", "SpatRaster")(SG)
-                co <- bb[,1]+(cs/2)
-                cd <- c(getMethod("ncol", "SpatRaster")(SG),
-                    getMethod("nrow", "SpatRaster")(SG))
-                gt <- data.frame(cellcentre.offset=co, cellsize=cs,
-                    cells.dim=cd)
-                wkt_SG <- getMethod("crs", "SpatRaster")(SG)
-                lonlatSG <- getMethod("is.lonlat", "SpatRaster")(SG)
-            } else {
-                stop ("SG must be a SpatRaster or SpatialGrid object")
-            }
-            lonlat <- !is.na(lonlatSG) && lonlatSG
-        }
-        cat("proj:       ", ifelse(lonlat, 3, 99), "\n", file=pfile)
-        cat("zone:       0\n", file=pfile, append=TRUE)
-        cat("north:      ", ifelse(mSG, bb[2, "max"], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("south:      ", ifelse(mSG, bb[2, "min"], 0), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("east:       ", ifelse(mSG, bb[1, "max"], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("west:       ", ifelse(mSG, bb[1, "min"], 0), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("cols:       ", ifelse(mSG, gt$cells.dim[1], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("rows:       ", ifelse(mSG, gt$cells.dim[2], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("e-w resol:  ", ifelse(mSG, gt$cellsize[1], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("n-s resol:  ", ifelse(mSG, gt$cellsize[2], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("top:        1\n", sep="", file=pfile, append=TRUE)
-        cat("bottom:     0\n", sep="", file=pfile, append=TRUE)
-        cat("cols3:      ", ifelse(mSG, gt$cells.dim[1], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("rows3:      ", ifelse(mSG, gt$cells.dim[2], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("depths:     1\n", sep="", file=pfile, append=TRUE)
-        cat("e-w resol3: ", ifelse(mSG, gt$cellsize[1], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("n-s resol3: ", ifelse(mSG, gt$cellsize[2], 1), "\n",
-            sep="", file=pfile, append=TRUE)
-        cat("t-b resol:  1\n", sep="", file=pfile, append=TRUE)
+    Sys.setenv(GISRC = paste(Sys.getenv("HOME"), "\\.grassrc", gv, sep = ""))
+    if (file.exists(Sys.getenv("GISRC")) && !override)
+      ask_override(paste("A GISRC file", Sys.getenv("GISRC"), "already exists"),
+        missing_override = missing(override),
+        envir = environment()
+      )
+    fn_gisrc <- "junk"
+    if (isTRUE(file.access(".", 2) == 0)) {
+      Sys.setenv(GISRC = fn_gisrc)
+    } else {
+      warning("working directory not writable, using tempfile for GISRC")
+      Sys.setenv(GISRC = paste0(tempfile(), "_", fn_gisrc))
     }
+    cat("GISDBASE:", getwd(), "\n", file = Sys.getenv("GISRC"))
+    cat("LOCATION_NAME: <UNKNOWN>", "\n",
+      file = Sys.getenv("GISRC"),
+      append = TRUE
+    )
+    cat("MAPSET: <UNKNOWN>", "\n",
+      file = Sys.getenv("GISRC"),
+      append = TRUE
+    )
+    gisrc <- ifelse(use_g.dirseps.exe, system(paste(
+      "g.dirseps.exe -g",
+      shQuote(Sys.getenv("GISRC"))
+    ), intern = TRUE),
+    Sys.getenv("GISRC")
+    )
+    assign("addEXE", .addexe(), envir = .GRASS_CACHE)
+    Sys.setenv(GISRC = gisrc)
+    if (!missing(gisDbase)) {
+      if (!file.exists(gisDbase)) dir.create(gisDbase)
+    } else {
+      gisDbase <- tempdir()
+    }
+    gisDbase <- ifelse(use_g.dirseps.exe, system(paste(
+      "g.dirseps.exe -g",
+      shQuote(gisDbase)
+    ), intern = TRUE), gisDbase)
+  } else if (SYS == "unix") {
+    OSGEO4W_ROOT <- ""
+    Sys.setenv(GISBASE = gisBase)
+    if (missing(home)) home <- Sys.getenv("HOME")
+    if (missing(addon_base))
+      addon_base <- paste(Sys.getenv("HOME"), "/.grass", gv, "/addons", sep = "")
+    addon_res <- file.exists(
+      addon_base, paste(addon_base, "/bin", sep = ""),
+      paste(addon_base, "/scripts", sep = "")
+    )
+    if (any(addon_res)) Sys.setenv("GRASS_ADDON_BASE" = addon_base)
+    ePATH <- Sys.getenv("PATH")
+    if (length(grep(basename(Sys.getenv("GISBASE")), ePATH)) < 1) {
+      Sys.setenv(PATH = paste(Sys.getenv("GISBASE"), "/bin:",
+        Sys.getenv("GISBASE"), "/scripts",
+        ifelse(addon_res[2],
+          paste(":", Sys.getenv("GRASS_ADDON_BASE"), "/bin", sep = ""), ""
+        ),
+        ifelse(addon_res[3],
+          paste(":", Sys.getenv("GRASS_ADDON_BASE"), "/scripts", sep = ""),
+          ""
+        ),
+        ifelse(nchar(ePATH) == 0, "", ":"), ePATH,
+        sep = ""
+      ))
+    }
+    eLDPATH <- Sys.getenv("LD_LIBRARY_PATH")
+    if (length(grep(basename(Sys.getenv("GISBASE")), eLDPATH)) < 1) {
+      Sys.setenv(LD_LIBRARY_PATH = paste(Sys.getenv("GISBASE"), "/lib:",
+        ifelse(nchar(eLDPATH) == 0, "", ":"), eLDPATH,
+        sep = ""
+      ))
+    }
+    # FIXME Sys.info()["sysname"] == "Darwin"
+    Sys.setenv(GISRC = paste(home, "/.grassrc", gv, sep = ""))
+    # FIXME
+    if (file.exists(Sys.getenv("GISRC")) && !override)
+      ask_override(paste("A GISRC file", Sys.getenv("GISRC"), "already exists"),
+        missing_override = missing(override),
+        envir = environment()
+      )
+    ePyPATH <- Sys.getenv("PYTHONPATH")
+    if (length(grep(basename(Sys.getenv("GISBASE")), ePyPATH)) < 1 ||
+      nchar(ePyPATH) == 0) {
+      GrPyPATH <- paste(Sys.getenv("GISBASE"), "etc", "python", sep = "/")
+      if (nchar(ePyPATH) > 0)
+        Sys.setenv(PYTHONPATH = paste(GrPyPATH, ePyPATH, sep = ":"))
+      else Sys.setenv(PYTHONPATH = GrPyPATH)
+    }
+    if (!missing(gisDbase)) {
+      if (!file.exists(gisDbase)) dir.create(gisDbase)
+    } else {
+      gisDbase <- tempdir()
+    }
+    cat("GISDBASE:", gisDbase, "\n", file = Sys.getenv("GISRC"))
+    cat("LOCATION_NAME: <UNKNOWN>", "\n",
+      file = Sys.getenv("GISRC"),
+      append = TRUE
+    )
+    cat("MAPSET: <UNKNOWN>", "\n",
+      file = Sys.getenv("GISRC"),
+      append = TRUE
+    )
+  } else stop(paste("Platform variant", SYS, "not supported"))
+  set.GIS_LOCK(pid)
+  assign("INIT_USED", TRUE, envir = .GRASS_CACHE)
+  assign("GIS_LOCK", pid, envir = .GRASS_CACHE)
+  if (remove_GISRC) assign("remove_GISRC", remove_GISRC, envir = .GRASS_CACHE)
+  system(paste(
+    paste("g.gisenv", get("addEXE", envir = .GRASS_CACHE), sep = ""),
+    shQuote(paste("set=GISDBASE=", gisDbase))
+  ))
+  if (missing(location)) location <- basename(tempfile())
+  loc_path <- paste(gisDbase, location, sep = "/")
+  if (!file.exists(loc_path)) dir.create(loc_path)
+  if (!file.exists(paste(loc_path, "PERMANENT", sep = "/")))
+    dir.create(paste(loc_path, "PERMANENT", sep = "/"))
+  if (missing(mapset)) mapset <- basename(tempfile())
+  if (!file.exists(paste(loc_path, mapset, sep = "/")))
+    dir.create(paste(loc_path, mapset, sep = "/"))
+  system(paste(
+    paste("g.gisenv", get("addEXE", envir = .GRASS_CACHE), sep = ""),
+    shQuote(paste("set=GISDBASE", gisDbase, sep = "="))
+  ))
+  system(paste(
+    paste("g.gisenv", get("addEXE", envir = .GRASS_CACHE), sep = ""),
+    shQuote(paste("set=LOCATION_NAME", location, sep = "="))
+  ))
+  system(paste(
+    paste("g.gisenv", get("addEXE", envir = .GRASS_CACHE), sep = ""),
+    shQuote(paste("set=MAPSET", mapset, sep = "="))
+  ))
+  system(paste(
+    paste("g.gisenv", get("addEXE", envir = .GRASS_CACHE), sep = ""),
+    shQuote("set=GRASS_GUI=text")
+  ))
+  Sys.setenv(GISBASE = gisBase)
+  Sys.setenv(GISDBASE = gisDbase)
+  Sys.setenv(LOCATION_NAME = location)
+  Sys.setenv(MAPSET = mapset)
+  gv <- system(paste("g.version", get("addEXE", envir = .GRASS_CACHE),
+    sep = ""
+  ), intern = TRUE)
 
-    tfile <- paste(loc_path, "PERMANENT", "WIND", sep="/")
-    if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
-    tfile <- paste(loc_path, mapset, "WIND", sep="/")
-    if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite=TRUE)
-    execGRASS("g.region", save="input", flags="overwrite",
-        ignore.stderr=ignore.stderr)
+
+  comp <- .compatibleGRASSVersion(gv)
+  if (!comp) {
+    stop(attr(comp, "message"))
+  }
+  grass_python <- Sys.getenv("GRASS_PYTHON")
+  if (grass_python == "") {
+    if (nchar(OSGEO4W_ROOT) > 0) {
+      if (file.exists(paste(OSGEO4W_ROOT, "bin/python3.exe", sep = "/"))) {
+        Sys.setenv("GRASS_PYTHON" = paste(OSGEO4W_ROOT, "bin/python3.exe", sep = "/"))
+      } else {
+        Sys.setenv("GRASS_PYTHON" = paste(OSGEO4W_ROOT, "bin/python.exe", sep = "/"))
+      }
+    } else {
+      if (strsplit(system(paste("g.version", get("addEXE", envir = .GRASS_CACHE), " -g ", sep = ""), intern = TRUE)[1], "=")[[1]][2] > "7.6.1")
+        Sys.setenv("GRASS_PYTHON" = paste("python3", get("addEXE",
+          envir = .GRASS_CACHE
+        ), sep = ""))
+      else
+        Sys.setenv("GRASS_PYTHON" = paste("python", get("addEXE",
+          envir = .GRASS_CACHE
+        ), sep = ""))
+    }
+  }
+
+  assign("GV", gv, envir = .GRASS_CACHE)
+  pfile <- paste(loc_path, "PERMANENT", "DEFAULT_WIND", sep = "/")
+  mSG <- FALSE
+  if (!file.exists(pfile)) {
+    lonlat <- FALSE
+    mSG <- !missing(SG)
     if (mSG) {
-        if (nzchar(wkt_SG)) {
-            tf <- tempfile()
-            writeLines(wkt_SG, con=tf)
-            MS <- execGRASS("g.mapset", flags="p", intern=TRUE,
-                ignore.stderr=ignore.stderr)
-	    if (MS != "PERMANENT")
-                execGRASS("g.mapset", mapset="PERMANENT", flags="quiet",
-                    ignore.stderr=ignore.stderr)
-            tull <- execGRASS("g.proj", flags="c", wkt=tf,
-                ignore.stderr=ignore.stderr, intern=TRUE)
-            execGRASS("g.region", flags="s", region=paste0("input@", mapset),
-                ignore.stderr=ignore.stderr)
-            execGRASS("g.region", flags="d", ignore.stderr=ignore.stderr)
-	    if (MS != "PERMANENT")
-                execGRASS("g.mapset", mapset=mapset, flags="quiet",
-                    ignore.stderr=ignore.stderr)
-        }
+      if (inherits(SG, "SpatialGrid")) {
+        if (!requireNamespace("sp", quietly = TRUE))
+          stop("The sp package is required for the SG argument")
+        bb <- sp::bbox(SG)
+        gt <- sp::gridparameters(SG)
+        wkt_SG <- sp::wkt(SG)
+        lonlatSG <- !sp::is.projected(SG)
+      } else if (inherits(SG, "SpatRaster")) {
+        if (!requireNamespace("terra", quietly = TRUE))
+          stop("The terra package is required for the SG argument")
+        bb <- getMethod("ext", "SpatRaster")(SG)
+        bb <- as.vector(bb)
+        bb <- matrix(bb, 2, 2, byrow = TRUE)
+        colnames(bb) <- c("min", "max")
+        cs <- getMethod("res", "SpatRaster")(SG)
+        co <- bb[, 1] + (cs / 2)
+        cd <- c(
+          getMethod("ncol", "SpatRaster")(SG),
+          getMethod("nrow", "SpatRaster")(SG)
+        )
+        gt <- data.frame(
+          cellcentre.offset = co, cellsize = cs,
+          cells.dim = cd
+        )
+        wkt_SG <- getMethod("crs", "SpatRaster")(SG)
+        lonlatSG <- getMethod("is.lonlat", "SpatRaster")(SG)
+      } else {
+        stop("SG must be a SpatRaster or SpatialGrid object")
+      }
+      lonlat <- !is.na(lonlatSG) && lonlatSG
     }
-    gmeta(ignore.stderr=ignore.stderr)
+    cat("proj:       ", ifelse(lonlat, 3, 99), "\n", file = pfile)
+    cat("zone:       0\n", file = pfile, append = TRUE)
+    cat("north:      ", ifelse(mSG, bb[2, "max"], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("south:      ", ifelse(mSG, bb[2, "min"], 0), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("east:       ", ifelse(mSG, bb[1, "max"], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("west:       ", ifelse(mSG, bb[1, "min"], 0), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("cols:       ", ifelse(mSG, gt$cells.dim[1], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("rows:       ", ifelse(mSG, gt$cells.dim[2], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("e-w resol:  ", ifelse(mSG, gt$cellsize[1], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("n-s resol:  ", ifelse(mSG, gt$cellsize[2], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("top:        1\n", sep = "", file = pfile, append = TRUE)
+    cat("bottom:     0\n", sep = "", file = pfile, append = TRUE)
+    cat("cols3:      ", ifelse(mSG, gt$cells.dim[1], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("rows3:      ", ifelse(mSG, gt$cells.dim[2], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("depths:     1\n", sep = "", file = pfile, append = TRUE)
+    cat("e-w resol3: ", ifelse(mSG, gt$cellsize[1], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("n-s resol3: ", ifelse(mSG, gt$cellsize[2], 1), "\n",
+      sep = "", file = pfile, append = TRUE
+    )
+    cat("t-b resol:  1\n", sep = "", file = pfile, append = TRUE)
+  }
+
+  tfile <- paste(loc_path, "PERMANENT", "WIND", sep = "/")
+  if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite = TRUE)
+  tfile <- paste(loc_path, mapset, "WIND", sep = "/")
+  if (!file.exists(tfile)) file.copy(pfile, tfile, overwrite = TRUE)
+  execGRASS("g.region",
+    save = "input", flags = "overwrite",
+    ignore.stderr = ignore.stderr
+  )
+  if (mSG) {
+    if (nzchar(wkt_SG)) {
+      tf <- tempfile()
+      writeLines(wkt_SG, con = tf)
+      MS <- execGRASS("g.mapset",
+        flags = "p", intern = TRUE,
+        ignore.stderr = ignore.stderr
+      )
+      if (MS != "PERMANENT")
+        execGRASS("g.mapset",
+          mapset = "PERMANENT", flags = "quiet",
+          ignore.stderr = ignore.stderr
+        )
+      tull <- execGRASS("g.proj",
+        flags = "c", wkt = tf,
+        ignore.stderr = ignore.stderr, intern = TRUE
+      )
+      execGRASS("g.region",
+        flags = "s", region = paste0("input@", mapset),
+        ignore.stderr = ignore.stderr
+      )
+      execGRASS("g.region", flags = "d", ignore.stderr = ignore.stderr)
+      if (MS != "PERMANENT")
+        execGRASS("g.mapset",
+          mapset = mapset, flags = "quiet",
+          ignore.stderr = ignore.stderr
+        )
+    }
+  }
+  gmeta(ignore.stderr = ignore.stderr)
 }
 
 remove_GISRC <- function() {
-    if (get("INIT_USED", envir=.GRASS_CACHE) &&
-        get("remove_GISRC", envir=.GRASS_CACHE)) {
-        gisrc <- Sys.getenv("GISRC")
-        if (file.exists(gisrc)) unlink(gisrc)
-        Sys.unsetenv("GISRC")
-    }
+  if (get("INIT_USED", envir = .GRASS_CACHE) &&
+    get("remove_GISRC", envir = .GRASS_CACHE)) {
+    gisrc <- Sys.getenv("GISRC")
+    if (file.exists(gisrc)) unlink(gisrc)
+    Sys.unsetenv("GISRC")
+  }
 }

--- a/R/options.R
+++ b/R/options.R
@@ -3,85 +3,84 @@
 #
 # needed
 set.ignore.stderrOption <- function(value) {
-	if (!is.logical(value)) stop ("logical argument required")
-	res <- get("ignore.stderr", envir = .GRASS_CACHE)
-	assign("ignore.stderr", value, envir = .GRASS_CACHE)
-	res
+  if (!is.logical(value)) stop("logical argument required")
+  res <- get("ignore.stderr", envir = .GRASS_CACHE)
+  assign("ignore.stderr", value, envir = .GRASS_CACHE)
+  res
 }
 
 get.ignore.stderrOption <- function() {
-	get("ignore.stderr", envir = .GRASS_CACHE)
+  get("ignore.stderr", envir = .GRASS_CACHE)
 }
 # needed
 set.stop_on_no_flags_parasOption <- function(value) {
-	if (!is.logical(value)) stop ("logical argument required")
-	res <- get("stop_on_no_flags_paras", envir = .GRASS_CACHE)
-	assign("stop_on_no_flags_paras", value, envir = .GRASS_CACHE)
-	res
+  if (!is.logical(value)) stop("logical argument required")
+  res <- get("stop_on_no_flags_paras", envir = .GRASS_CACHE)
+  assign("stop_on_no_flags_paras", value, envir = .GRASS_CACHE)
+  res
 }
 
 get.stop_on_no_flags_parasOption <- function() {
-	get("stop_on_no_flags_paras", envir = .GRASS_CACHE)
+  get("stop_on_no_flags_paras", envir = .GRASS_CACHE)
 }
 
 set.echoCmdOption <- function(value) {
-	if (!is.logical(value)) stop ("logical argument required")
-	res <- get("echoCmd", envir = .GRASS_CACHE)
-	assign("echoCmd", value, envir = .GRASS_CACHE)
-	res
+  if (!is.logical(value)) stop("logical argument required")
+  res <- get("echoCmd", envir = .GRASS_CACHE)
+  assign("echoCmd", value, envir = .GRASS_CACHE)
+  res
 }
 
 get.echoCmdOption <- function() {
-	get("echoCmd", envir = .GRASS_CACHE)
+  get("echoCmd", envir = .GRASS_CACHE)
 }
 
 set.useInternOption <- function(value) {
-	if (!is.logical(value)) stop ("logical argument required")
-	res <- get("useIntern", envir = .GRASS_CACHE)
-	assign("useIntern", value, envir = .GRASS_CACHE)
-	res
+  if (!is.logical(value)) stop("logical argument required")
+  res <- get("useIntern", envir = .GRASS_CACHE)
+  assign("useIntern", value, envir = .GRASS_CACHE)
+  res
 }
 
 get.useInternOption <- function() {
-	get("useIntern", envir = .GRASS_CACHE)
+  get("useIntern", envir = .GRASS_CACHE)
 }
 
 set.legacyExecOption <- function(value) {
-	if (!is.logical(value)) stop ("logical argument required")
-	res <- get("legacyExec", envir = .GRASS_CACHE)
-	assign("legacyExec", value, envir = .GRASS_CACHE)
-	res
+  if (!is.logical(value)) stop("logical argument required")
+  res <- get("legacyExec", envir = .GRASS_CACHE)
+  assign("legacyExec", value, envir = .GRASS_CACHE)
+  res
 }
 
 get.legacyExecOption <- function() {
-	get("legacyExec", envir = .GRASS_CACHE)
+  get("legacyExec", envir = .GRASS_CACHE)
 }
 
 set.defaultFlagsOption <- function(value) {
-	res <- get("defaultFlags", envir = .GRASS_CACHE)
-        if (is.null(value)) {
-	    assign("defaultFlags", value, envir = .GRASS_CACHE)
-        } else {
-	    if (!is.character(value)) stop ("character argument required")
-            stopifnot(length(value) > 0)
-            stopifnot(all(value %in% c("quiet", "verbose")))
-	    assign("defaultFlags", value, envir = .GRASS_CACHE)
-        }
-	res
+  res <- get("defaultFlags", envir = .GRASS_CACHE)
+  if (is.null(value)) {
+    assign("defaultFlags", value, envir = .GRASS_CACHE)
+  } else {
+    if (!is.character(value)) stop("character argument required")
+    stopifnot(length(value) > 0)
+    stopifnot(all(value %in% c("quiet", "verbose")))
+    assign("defaultFlags", value, envir = .GRASS_CACHE)
+  }
+  res
 }
 
 get.defaultFlagsOption <- function() {
-	get("defaultFlags", envir = .GRASS_CACHE)
+  get("defaultFlags", envir = .GRASS_CACHE)
 }
 
 set.suppressEchoCmdInFuncOption <- function(value) {
-	if (!is.logical(value)) stop ("logical argument required")
-	res <- get("suppressEchoCmdInFunc", envir = .GRASS_CACHE)
-	assign("suppressEchoCmdInFunc", value, envir = .GRASS_CACHE)
-	res
+  if (!is.logical(value)) stop("logical argument required")
+  res <- get("suppressEchoCmdInFunc", envir = .GRASS_CACHE)
+  assign("suppressEchoCmdInFunc", value, envir = .GRASS_CACHE)
+  res
 }
 
 get.suppressEchoCmdInFuncOption <- function() {
-	get("suppressEchoCmdInFunc", envir = .GRASS_CACHE)
+  get("suppressEchoCmdInFunc", envir = .GRASS_CACHE)
 }
-

--- a/R/rast_link.R
+++ b/R/rast_link.R
@@ -2,595 +2,662 @@
 # Copyright (c) 2022 Roger S. Bivand
 #
 
-read_RAST <- function(vname, cat=NULL, NODATA=NULL, 
-    ignore.stderr=get.ignore.stderrOption(), return_format="terra", 
-    close_OK=return_format=="SGDF", flags=NULL) {
+read_RAST <- function(
+    vname, cat = NULL, NODATA = NULL,
+    ignore.stderr = get.ignore.stderrOption(), return_format = "terra",
+    close_OK = return_format == "SGDF", flags = NULL) {
+  if (!is.null(cat))
+    if (length(vname) != length(cat))
+      stop("vname and cat not same length")
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- set.echoCmdOption(FALSE)
+  }
+  if (close_OK) {
+    openedConns <- as.integer(row.names(showConnections()))
+  }
+  stopifnot(is.logical(ignore.stderr))
 
-    if (!is.null(cat))
-        if(length(vname) != length(cat)) 
-	    stop("vname and cat not same length")
-    if (get.suppressEchoCmdInFuncOption()) {
-        inEchoCmd <- set.echoCmdOption(FALSE)
+  if (!is.null(NODATA)) {
+    if (any(!is.finite(NODATA)) || any(!is.numeric(NODATA)))
+      stop("invalid NODATA value")
+    if (NODATA != round(NODATA))
+      warning("NODATA rounded to integer")
+    NODATA <- round(NODATA)
+    if (length(NODATA) != length(vname))
+      NODATA <- rep(NODATA[1], length.out = length(vname))
+  }
+
+  msp <- unlist(strsplit(execGRASS("g.mapsets",
+    flags = "p",
+    intern = TRUE
+  ), " "))
+
+  if (return_format == "SGDF") {
+    if (!(requireNamespace("sp", quietly = TRUE)))
+      stop("sp required for SGDF output")
+    resa <- .read_rast_non_plugin_ng(
+      vname = vname, cat = cat, NODATA = NODATA,
+      ignore.stderr = ignore.stderr
+    )
+    if (close_OK) { # closeAllConnections()
+      openConns_now <- as.integer(row.names(showConnections()))
+      toBeClosed <- openConns_now[!(openConns_now %in% openedConns)]
+      for (bye in toBeClosed) close(bye)
     }
-    if (close_OK) {
-        openedConns <- as.integer(row.names(showConnections()))
+  } else {
+    if (!(requireNamespace("terra", quietly = TRUE)))
+      stop("terra required for SpatRaster output")
+    drv <- "RRASTER"
+    fxt <- ".grd"
+    ro <- FALSE
+    o <- execGRASS("r.out.gdal", flags = "l", intern = TRUE)
+    oo <- grep("RRASTER", o)
+    if (length(oo) == 0L) ro <- TRUE
+    if (!ro) {
+      RR <- o[oo]
+      RRs <- strsplit(RR, " ")[[1]]
+      if (length(grep("\\(rw", RRs)) == 0L) ro <- TRUE
     }
-    stopifnot(is.logical(ignore.stderr))
-
-    if (!is.null(NODATA)) {
-        if (any(!is.finite(NODATA)) || any(!is.numeric(NODATA)))
-            stop("invalid NODATA value")
-	if (NODATA != round(NODATA)) 
-	    warning("NODATA rounded to integer")
-	NODATA <- round(NODATA)
-        if (length(NODATA) != length(vname)) 
-            NODATA <- rep(NODATA[1], length.out=length(vname))
-     }
-
-    msp <- unlist(strsplit(execGRASS("g.mapsets", flags="p",
-        intern=TRUE), " "))
-
-    if (return_format == "SGDF") {
-        if (!(requireNamespace("sp", quietly=TRUE)))
-            stop("sp required for SGDF output")
-        resa <- .read_rast_non_plugin_ng(vname=vname, cat=cat, NODATA=NODATA, 
-            ignore.stderr=ignore.stderr)
-        if (close_OK) { #closeAllConnections()
-            openConns_now <- as.integer(row.names(showConnections()))
-            toBeClosed <- openConns_now[!(openConns_now %in% openedConns)]
-            for (bye in toBeClosed) close(bye)
-        }
-    } else {
-        if (!(requireNamespace("terra", quietly=TRUE))) 
-            stop("terra required for SpatRaster output")
-        drv <- "RRASTER"
-        fxt <- ".grd"
-        ro <- FALSE
-        o <- execGRASS("r.out.gdal", flags="l", intern=TRUE)
-        oo <- grep("RRASTER", o)
-        if (length(oo) == 0L) ro <- TRUE
-        if (!ro) {
-            RR <- o[oo]
-            RRs <- strsplit(RR, " ")[[1]]
-            if (length(grep("\\(rw", RRs)) == 0L) ro <- TRUE
-        }
-        if (ro) {
-            drv <- "GTiff"
-            fxt <- ".tif"
-        }
-        reslist <- vector(mode="list", length=length(vname))
-        names(reslist) <- gsub("@", "_", vname)
-        tmplist <- vector(mode="list", length=length(vname))
-        names(tmplist) <- gsub("@", "_", vname)
-        for (i in seq(along=vname)) {
-# 130422 at rgdal 0.8-8 GDAL.close(DS)
-# 061107 Dylan Beaudette NODATA
-# 071009 Markus Neteler's idea to use range
-            vca <- unlist(strsplit(vname[i], "@"))
-            if (length(vca) == 1L) {
-                exsts <- execGRASS("g.list", type="raster", pattern=vca[1],
-                intern=TRUE, ignore.stderr=ignore.stderr)
-                if (length(exsts) > 1L) stop("multiple rasters named ", vca[1],
-                     " found in in mapsets in search path: ",
-                      paste(msp, collapse=", "), 
-                      " ; use full path with @ to choose the required raster")
-                if (length(exsts) == 0L || exsts != vca[1])
-                    stop(vname[i], " not found in mapsets in search path: ",
-                      paste(msp, collapse=", "))
-            } else if (length(vca) == 2L) {
-                exsts <- execGRASS("g.list", type="raster", pattern=vca[1],
-                mapset=vca[2], intern=TRUE, ignore.stderr=ignore.stderr)
-                if (length(exsts) == 0L || exsts != vca[1])
-                    stop(vname[i], " not found in mapset: ", vca[2])
-            } else stop(vname[i], " incorrectly formatted")
-            typei <- NULL
-            if (is.null(NODATA)) {
-	        tx <- execGRASS("r.info", flags="r", map=vname[i], intern=TRUE, 
-	            ignore.stderr=ignore.stderr)
-	        tx <- gsub("=", ":", tx)
-	        con <- textConnection(tx)
-                res <- read.dcf(con)
-	        close(con)
-	        lres <- as.list(res)
-	        names(lres) <- colnames(res)
-	        lres <- lapply(lres, function(x)
-                ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
-	        tx <- execGRASS("r.info", flags="g", map=vname[i], intern=TRUE, 
-	            ignore.stderr=ignore.stderr)
-	        tx <- gsub("=", ":", tx)
-	        con <- textConnection(tx)
-                res <- read.dcf(con)
-	        close(con)
-	        l1res <- as.list(res)
-	        names(l1res) <- colnames(res)
-		CELL <- l1res$datatype == "CELL"
-                NODATAi <- NULL
-	        if (!is.numeric(lres$min) || 
-	           !is.finite(as.double(lres$min))) {
-                     stop("set NODATA manually to a feasible value")
-	        } else {
-	            lres$min <- floor(as.double(lres$min))
-		    may_be_u <- all(c(lres$min, lres$max) >= 0)
-                    if (may_be_u && CELL) {
-                        if (lres$max < 4294967295) {
-                            NODATAi <- 4294967295
-                            typei <- "UInt32"
-                        } else if (lres$max == 4294967295) {
-                            if (lres$min > 0) {
-                                NODATAi <- 0
-                            } else {
-                                stop("set NODATA manually to a feasible value")
-                            }
-                        }
-                        if (lres$max < 65535) {
-                            NODATAi <- 65535
-                        } else if (lres$max == 65535) {
-                            if (lres$min > 0) {
-                                NODATAi <- 0
-                                typei <- "UInt16"
-                            } else {
-                                stop("set NODATA manually to a feasible value")
-                            }
-                        }
-                        if (lres$max < 255) {
-                            NODATAi <- 255
-                        } else if (lres$max == 255) {
-                            if (lres$min > 0) {
-                                NODATAi <- 0
-                                typei <- "Byte"
-                            } else {
-                                stop("set NODATA manually to a feasible value")
-                            }
-                        }
-                    } else if (!may_be_u && CELL) {
-                        if (lres$min == -2147483648) {
-                            if (lres$max < 2147483647) {
-                                NODATAi <- 2147483647
-                                typei <- "Int32"
-                            } else stop("set NODATA manually to a feasible value")
-                        }    
-                        if (lres$min == -32768) {
-                            if (lres$max < 32767) {
-                                NODATAi <- 32767
-                                typei <- "Int16"
-                            } else stop("set NODATA manually to a feasible value")
-                        }
-                        if (is.null(NODATAi)) NODATAi <- floor(lres$min) - 1
-                    } else {
-	                NODATAi <- floor(lres$min) - 1
-                    }
-	        }
-            } else NODATAi <- NODATA[i]
-            tmplist[[i]] <- tempfile(fileext=fxt)
-            if (is.null(flags)) flags <- c("overwrite", "c", "m")
-            if (!is.null(cat) && cat[i]) flags <- c(flags, "t")
-            if (is.null(typei)) {
-                execGRASS("r.out.gdal", input=vname[i], output=tmplist[[i]],
-                    format=drv, nodata=NODATAi, flags=flags,
-                    ignore.stderr=ignore.stderr)
-            } else {
-                execGRASS("r.out.gdal", input=vname[i], output=tmplist[[i]],
-                    format=drv, nodata=NODATAi, type=typei, flags=flags,
-                    ignore.stderr=ignore.stderr)
+    if (ro) {
+      drv <- "GTiff"
+      fxt <- ".tif"
+    }
+    reslist <- vector(mode = "list", length = length(vname))
+    names(reslist) <- gsub("@", "_", vname)
+    tmplist <- vector(mode = "list", length = length(vname))
+    names(tmplist) <- gsub("@", "_", vname)
+    for (i in seq(along = vname)) {
+      # 130422 at rgdal 0.8-8 GDAL.close(DS)
+      # 061107 Dylan Beaudette NODATA
+      # 071009 Markus Neteler's idea to use range
+      vca <- unlist(strsplit(vname[i], "@"))
+      if (length(vca) == 1L) {
+        exsts <- execGRASS("g.list",
+          type = "raster", pattern = vca[1],
+          intern = TRUE, ignore.stderr = ignore.stderr
+        )
+        if (length(exsts) > 1L) stop(
+          "multiple rasters named ", vca[1],
+          " found in in mapsets in search path: ",
+          paste(msp, collapse = ", "),
+          " ; use full path with @ to choose the required raster"
+        )
+        if (length(exsts) == 0L || exsts != vca[1])
+          stop(
+            vname[i], " not found in mapsets in search path: ",
+            paste(msp, collapse = ", ")
+          )
+      } else if (length(vca) == 2L) {
+        exsts <- execGRASS("g.list",
+          type = "raster", pattern = vca[1],
+          mapset = vca[2], intern = TRUE, ignore.stderr = ignore.stderr
+        )
+        if (length(exsts) == 0L || exsts != vca[1])
+          stop(vname[i], " not found in mapset: ", vca[2])
+      } else stop(vname[i], " incorrectly formatted")
+      typei <- NULL
+      if (is.null(NODATA)) {
+        tx <- execGRASS("r.info",
+          flags = "r", map = vname[i], intern = TRUE,
+          ignore.stderr = ignore.stderr
+        )
+        tx <- gsub("=", ":", tx)
+        con <- textConnection(tx)
+        res <- read.dcf(con)
+        close(con)
+        lres <- as.list(res)
+        names(lres) <- colnames(res)
+        lres <- lapply(lres, function(x)
+          ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
+        tx <- execGRASS("r.info",
+          flags = "g", map = vname[i], intern = TRUE,
+          ignore.stderr = ignore.stderr
+        )
+        tx <- gsub("=", ":", tx)
+        con <- textConnection(tx)
+        res <- read.dcf(con)
+        close(con)
+        l1res <- as.list(res)
+        names(l1res) <- colnames(res)
+        CELL <- l1res$datatype == "CELL"
+        NODATAi <- NULL
+        if (!is.numeric(lres$min) ||
+          !is.finite(as.double(lres$min))) {
+          stop("set NODATA manually to a feasible value")
+        } else {
+          lres$min <- floor(as.double(lres$min))
+          may_be_u <- all(c(lres$min, lres$max) >= 0)
+          if (may_be_u && CELL) {
+            if (lres$max < 4294967295) {
+              NODATAi <- 4294967295
+              typei <- "UInt32"
+            } else if (lres$max == 4294967295) {
+              if (lres$min > 0) {
+                NODATAi <- 0
+              } else {
+                stop("set NODATA manually to a feasible value")
+              }
             }
-            reslist[[i]] <- getMethod("rast", "character")(tmplist[[i]])
-        }         
-        resa <- getMethod("rast", "list")(reslist)
+            if (lres$max < 65535) {
+              NODATAi <- 65535
+            } else if (lres$max == 65535) {
+              if (lres$min > 0) {
+                NODATAi <- 0
+                typei <- "UInt16"
+              } else {
+                stop("set NODATA manually to a feasible value")
+              }
+            }
+            if (lres$max < 255) {
+              NODATAi <- 255
+            } else if (lres$max == 255) {
+              if (lres$min > 0) {
+                NODATAi <- 0
+                typei <- "Byte"
+              } else {
+                stop("set NODATA manually to a feasible value")
+              }
+            }
+          } else if (!may_be_u && CELL) {
+            if (lres$min == -2147483648) {
+              if (lres$max < 2147483647) {
+                NODATAi <- 2147483647
+                typei <- "Int32"
+              } else stop("set NODATA manually to a feasible value")
+            }
+            if (lres$min == -32768) {
+              if (lres$max < 32767) {
+                NODATAi <- 32767
+                typei <- "Int16"
+              } else stop("set NODATA manually to a feasible value")
+            }
+            if (is.null(NODATAi)) NODATAi <- floor(lres$min) - 1
+          } else {
+            NODATAi <- floor(lres$min) - 1
+          }
+        }
+      } else NODATAi <- NODATA[i]
+      tmplist[[i]] <- tempfile(fileext = fxt)
+      if (is.null(flags)) flags <- c("overwrite", "c", "m")
+      if (!is.null(cat) && cat[i]) flags <- c(flags, "t")
+      if (is.null(typei)) {
+        execGRASS("r.out.gdal",
+          input = vname[i], output = tmplist[[i]],
+          format = drv, nodata = NODATAi, flags = flags,
+          ignore.stderr = ignore.stderr
+        )
+      } else {
+        execGRASS("r.out.gdal",
+          input = vname[i], output = tmplist[[i]],
+          format = drv, nodata = NODATAi, type = typei, flags = flags,
+          ignore.stderr = ignore.stderr
+        )
+      }
+      reslist[[i]] <- getMethod("rast", "character")(tmplist[[i]])
     }
-    if (get.suppressEchoCmdInFuncOption()) tull <- set.echoCmdOption(inEchoCmd)
-    
-    resa
+    resa <- getMethod("rast", "list")(reslist)
+  }
+  if (get.suppressEchoCmdInFuncOption()) tull <- set.echoCmdOption(inEchoCmd)
+
+  resa
 }
 
 
 .read_rast_non_plugin_ng <- function(vname, cat, NODATA, ignore.stderr) {
-    
-    pid <- as.integer(round(runif(1, 1, 1000)))
-        
-    gLP <- getLocationProj()
-    if (gLP == "XY location (unprojected)")
-        p4 <- sp::CRS(as.character(NA))
-    else
-        p4 <- sp::CRS(gLP)
+  pid <- as.integer(round(runif(1, 1, 1000)))
 
-    reslist <- vector(mode="list", length=length(vname))
-    names(reslist) <- gsub("@", "_", vname)
+  gLP <- getLocationProj()
+  if (gLP == "XY location (unprojected)")
+    p4 <- sp::CRS(as.character(NA))
+  else
+    p4 <- sp::CRS(gLP)
 
-    msp <- unlist(strsplit(execGRASS("g.mapsets", flags="p",
-        intern=TRUE), " "))
+  reslist <- vector(mode = "list", length = length(vname))
+  names(reslist) <- gsub("@", "_", vname)
 
-    for (i in seq(along=vname)) {
+  msp <- unlist(strsplit(execGRASS("g.mapsets",
+    flags = "p",
+    intern = TRUE
+  ), " "))
 
-        vca <- unlist(strsplit(vname[i], "@"))
-        if (length(vca) == 1L) {
-            exsts <- execGRASS("g.list", type="raster", pattern=vca[1],
-                intern=TRUE, ignore.stderr=ignore.stderr)
-            if (length(exsts) > 1L) stop("multiple rasters named ", vca[1],
-               " found in in mapsets in search path:\n",
-                  paste(msp, collapse=", "), 
-                "\nuse full path with @ to choose the required raster")
-            if (length(exsts) == 0L || exsts != vca[1])
-                stop(vname[i], " not found in mapsets in search path: ",
-                  paste(msp, collapse=", "))
-        } else if (length(vca) == 2L) {
-            exsts <- execGRASS("g.list", type="raster", pattern=vca[1],
-                mapset=vca[2], intern=TRUE, ignore.stderr=ignore.stderr)
-            if (length(exsts) == 0L || exsts != vca[1])
-                stop(vname[i], " not found in mapset: ", vca[2])
-        } else stop(vname[i], " incorrectly formatted")
-        glist <- execGRASS("r.info", flags="g", map=vname[i],
-            intern=TRUE, ignore.stderr=ignore.stderr)
-        whCELL <- glist[grep("datatype", glist)]
-	to_int <- length(which(unlist(strsplit(
-	    whCELL, "=")) == "CELL")) > 0
-        Dcell <- length(which(unlist(strsplit(
-	    whCELL, "=")) == "DCELL")) > 0
-
-	gtmpfl1 <- dirname(execGRASS("g.tempfile",
-	    pid=pid, intern=TRUE, ignore.stderr=ignore.stderr))
-	rtmpfl1 <- ifelse(.Platform$OS.type == "windows" &&
-            (Sys.getenv("OSTYPE") == "cygwin"), 
-	    system(paste("cygpath -w", gtmpfl1, sep=" "), 
-	    intern=TRUE), gtmpfl1)
-	gtmpfl11 <- paste(gtmpfl1, vname[i], sep=.Platform$file.sep)
-	rtmpfl11 <- paste(rtmpfl1, vname[i], sep=.Platform$file.sep)
-
-# 130422 at rgdal 0.8-8 GDAL.close(DS)
-# 061107 Dylan Beaudette NODATA
-# 071009 Markus Neteler's idea to use range
-    if (is.null(NODATA)) {
-	tx <- execGRASS("r.info", flags="r", map=vname[i], intern=TRUE, 
-	    ignore.stderr=ignore.stderr)
-	tx <- gsub("=", ":", tx)
-	con <- textConnection(tx)
-        res <- read.dcf(con)
-	close(con)
-	lres <- as.list(res)
-	names(lres) <- colnames(res)
-	lres <- lapply(lres, function(x)
-        ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
-	if (!is.numeric(lres$min) || 
-	    !is.finite(as.double(lres$min))) 
-            NODATAi <- as.integer(999)
-	else {
-	    lres$min <- floor(as.double(lres$min))
-	    NODATAi <- floor(lres$min) - 1
-	}
-    }
-
-        rOutBinFlags <- "b"
-# 120118 Rainer Krug
-        if (to_int) rOutBinFlags <- c(rOutBinFlags, "i")
-        else rOutBinFlags <- c(rOutBinFlags, "f")
-        rOutBinBytes <- 4L
-        if (Dcell) rOutBinBytes <- 8L
-        tryCatch({
-	    execGRASS("r.out.bin", flags=rOutBinFlags, 
-                input=vname[i], output=gtmpfl11, bytes=rOutBinBytes,
-                null=as.integer(NODATAi), ignore.stderr=ignore.stderr)
-                        
-                gdal_info <- bin_gdal_info_ng(rtmpfl11, to_int)
-                        
-                what <- ifelse(to_int, "integer", "double")
-                n <- gdal_info[1] * gdal_info[2]
-                size <- gdal_info[10]/8
-                        
-                reslist[[i]] <- readBinGridData(rtmpfl11, what=what,
-                    n=n, size=size, endian=attr(gdal_info, "endian"),
-                    nodata=attr(gdal_info, "nodata"))
-            }, finally = {
-                unlink(paste(rtmpfl1, list.files(rtmpfl1,
-                    pattern=vname[i]), sep=.Platform$file.sep))
-            }
+  for (i in seq(along = vname)) {
+    vca <- unlist(strsplit(vname[i], "@"))
+    if (length(vca) == 1L) {
+      exsts <- execGRASS("g.list",
+        type = "raster", pattern = vca[1],
+        intern = TRUE, ignore.stderr = ignore.stderr
+      )
+      if (length(exsts) > 1L) stop(
+        "multiple rasters named ", vca[1],
+        " found in in mapsets in search path:\n",
+        paste(msp, collapse = ", "),
+        "\nuse full path with @ to choose the required raster"
+      )
+      if (length(exsts) == 0L || exsts != vca[1])
+        stop(
+          vname[i], " not found in mapsets in search path: ",
+          paste(msp, collapse = ", ")
         )
+    } else if (length(vca) == 2L) {
+      exsts <- execGRASS("g.list",
+        type = "raster", pattern = vca[1],
+        mapset = vca[2], intern = TRUE, ignore.stderr = ignore.stderr
+      )
+      if (length(exsts) == 0L || exsts != vca[1])
+        stop(vname[i], " not found in mapset: ", vca[2])
+    } else stop(vname[i], " incorrectly formatted")
+    glist <- execGRASS("r.info",
+      flags = "g", map = vname[i],
+      intern = TRUE, ignore.stderr = ignore.stderr
+    )
+    whCELL <- glist[grep("datatype", glist)]
+    to_int <- length(which(unlist(strsplit(
+      whCELL, "="
+    )) == "CELL")) > 0
+    Dcell <- length(which(unlist(strsplit(
+      whCELL, "="
+    )) == "DCELL")) > 0
+
+    gtmpfl1 <- dirname(execGRASS("g.tempfile",
+      pid = pid, intern = TRUE, ignore.stderr = ignore.stderr
+    ))
+    rtmpfl1 <- ifelse(.Platform$OS.type == "windows" &&
+      (Sys.getenv("OSTYPE") == "cygwin"),
+    system(paste("cygpath -w", gtmpfl1, sep = " "),
+      intern = TRUE
+    ), gtmpfl1
+    )
+    gtmpfl11 <- paste(gtmpfl1, vname[i], sep = .Platform$file.sep)
+    rtmpfl11 <- paste(rtmpfl1, vname[i], sep = .Platform$file.sep)
+
+    # 130422 at rgdal 0.8-8 GDAL.close(DS)
+    # 061107 Dylan Beaudette NODATA
+    # 071009 Markus Neteler's idea to use range
+    if (is.null(NODATA)) {
+      tx <- execGRASS("r.info",
+        flags = "r", map = vname[i], intern = TRUE,
+        ignore.stderr = ignore.stderr
+      )
+      tx <- gsub("=", ":", tx)
+      con <- textConnection(tx)
+      res <- read.dcf(con)
+      close(con)
+      lres <- as.list(res)
+      names(lres) <- colnames(res)
+      lres <- lapply(lres, function(x)
+        ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
+      if (!is.numeric(lres$min) ||
+        !is.finite(as.double(lres$min)))
+        NODATAi <- as.integer(999)
+      else {
+        lres$min <- floor(as.double(lres$min))
+        NODATAi <- floor(lres$min) - 1
+      }
     }
 
-    co <- unname(c((gdal_info[4] + (gdal_info[6]/2)),
-        (gdal_info[5] + (gdal_info[7]/2))))
-    grid <- sp::GridTopology(co, unname(c(gdal_info[6], gdal_info[7])),
-        unname(c(gdal_info[2], gdal_info[1])))
+    rOutBinFlags <- "b"
+    # 120118 Rainer Krug
+    if (to_int) rOutBinFlags <- c(rOutBinFlags, "i")
+    else rOutBinFlags <- c(rOutBinFlags, "f")
+    rOutBinBytes <- 4L
+    if (Dcell) rOutBinBytes <- 8L
+    tryCatch({
+      execGRASS("r.out.bin",
+        flags = rOutBinFlags,
+        input = vname[i], output = gtmpfl11, bytes = rOutBinBytes,
+        null = as.integer(NODATAi), ignore.stderr = ignore.stderr
+      )
 
-    if (length(unique(sapply(reslist, length))) != 1)
-        stop ("bands differ in length")
+      gdal_info <- bin_gdal_info_ng(rtmpfl11, to_int)
 
-    df <- as.data.frame(reslist)
+      what <- ifelse(to_int, "integer", "double")
+      n <- gdal_info[1] * gdal_info[2]
+      size <- gdal_info[10] / 8
 
-    resa <- sp::SpatialGridDataFrame(grid=grid, data=df, proj4string=p4)
+      reslist[[i]] <- readBinGridData(rtmpfl11,
+        what = what,
+        n = n, size = size, endian = attr(gdal_info, "endian"),
+        nodata = attr(gdal_info, "nodata")
+      )
+    }, finally = {
+      unlink(paste(rtmpfl1, list.files(rtmpfl1,
+        pattern = vname[i]
+      ), sep = .Platform$file.sep))
+    })
+  }
 
-    if (!is.null(cat)) {
-	for (i in seq(along=cat)) {
-	    if (cat[i] && is.integer(resa@data[[i]])) {
+  co <- unname(c(
+    (gdal_info[4] + (gdal_info[6] / 2)),
+    (gdal_info[5] + (gdal_info[7] / 2))
+  ))
+  grid <- sp::GridTopology(
+    co, unname(c(gdal_info[6], gdal_info[7])),
+    unname(c(gdal_info[2], gdal_info[1]))
+  )
 
-	        rSTATS <- execGRASS("r.stats", flags=c("l", "quiet"),
-	            input=vname[i], intern=TRUE,
-                    ignore.stderr=ignore.stderr)
+  if (length(unique(sapply(reslist, length))) != 1)
+    stop("bands differ in length")
 
-		cats <- strsplit(rSTATS, " ")
-		catnos <- sapply(cats, function(x) x[1])
-		catlabs <- sapply(cats, 
-		    function(x) paste(x[-1], collapse=" "))
-		if (any(!is.na(match(catnos, "*")))) {
-		    isNA <- which(catnos == "*")
-		    catnos <- catnos[-isNA]
-		    catlabs <- catlabs[-isNA]
-		}
-                if (length(catlabs) > length(unique(catlabs))) {
-                    catlabs <- paste(catlabs, catnos, sep="_")
-                    warning("non-unique category labels; category number appended")
-                }
-# https://files.nc.gov/ncdeq/Energy+Mineral+and+Land+Resources/Geological+Survey/1985_state_geologic_map_500000_scale.pdf (catnos vector polygon IDs)
-		resa@data[[i]] <- factor(resa@data[[i]], 
-		    levels=catnos, labels=catlabs)
-            }
-	} 
+  df <- as.data.frame(reslist)
+
+  resa <- sp::SpatialGridDataFrame(grid = grid, data = df, proj4string = p4)
+
+  if (!is.null(cat)) {
+    for (i in seq(along = cat)) {
+      if (cat[i] && is.integer(resa@data[[i]])) {
+        rSTATS <- execGRASS("r.stats",
+          flags = c("l", "quiet"),
+          input = vname[i], intern = TRUE,
+          ignore.stderr = ignore.stderr
+        )
+
+        cats <- strsplit(rSTATS, " ")
+        catnos <- sapply(cats, function(x) x[1])
+        catlabs <- sapply(
+          cats,
+          function(x) paste(x[-1], collapse = " ")
+        )
+        if (any(!is.na(match(catnos, "*")))) {
+          isNA <- which(catnos == "*")
+          catnos <- catnos[-isNA]
+          catlabs <- catlabs[-isNA]
+        }
+        if (length(catlabs) > length(unique(catlabs))) {
+          catlabs <- paste(catlabs, catnos, sep = "_")
+          warning("non-unique category labels; category number appended")
+        }
+        # https://files.nc.gov/ncdeq/Energy+Mineral+and+Land+Resources/Geological+Survey/1985_state_geologic_map_500000_scale.pdf (catnos vector polygon IDs)
+        resa@data[[i]] <- factor(resa@data[[i]],
+          levels = catnos, labels = catlabs
+        )
+      }
     }
-    return(resa)
+  }
+  return(resa)
 }
 
 
 
 
 bin_gdal_info_ng <- function(fname, to_int) {
-	if (!file.exists(fname)) stop(paste("no such file:", fname))
-	if (!file.exists(paste(fname, "hdr", sep="."))) 
-		stop(paste("no such file:", paste(fname, "hdr", sep=".")))
-	if (!file.exists(paste(fname, "wld", sep="."))) 
-		stop(paste("no such file:", paste(fname, "wld", sep=".")))
-	con <- file(paste(fname, "hdr", sep="."), "r")
-	l8 <- readLines(con, n=8)
-	close(con)
-	l8 <- read.dcf(con <- textConnection(gsub(" ", ":", l8)))
-	close(con)
-	lres <- as.list(l8)
-	names(lres) <- colnames(l8)
-	lres$nrows <- as.integer(lres$nrows)
-	lres$ncols <- as.integer(lres$ncols)
-	lres$nbands <- as.integer(lres$nbands)
-	lres$nbits <- as.integer(lres$nbits)
-	lres$skipbytes <- as.integer(lres$skipbytes)
-	lres$nodata <- ifelse(to_int, as.integer(lres$nodata), 
-		as.numeric(lres$nodata))
-	lres$byteorder <- as.character(lres$byteorder)
-	endian <- .Platform$endian
-	if ((endian == "little" && lres$byteorder == "M") ||
-		(endian == "big" && lres$byteorder == "I")) endian <- "swap"
-	con <- file(paste(fname, "wld", sep="."), "r")
-	l6 <- readLines(con, n=6)
-	close(con)
-	lres$ewres <- abs(as.numeric(l6[1]))
-	lres$nsres <- abs(as.numeric(l6[4]))
-	lres$n_cc <- as.numeric(l6[6])
-	lres$w_cc <- as.numeric(l6[5])
-	lres$s_cc <- lres$n_cc - lres$nsres * (lres$nrows-1)
+  if (!file.exists(fname)) stop(paste("no such file:", fname))
+  if (!file.exists(paste(fname, "hdr", sep = ".")))
+    stop(paste("no such file:", paste(fname, "hdr", sep = ".")))
+  if (!file.exists(paste(fname, "wld", sep = ".")))
+    stop(paste("no such file:", paste(fname, "wld", sep = ".")))
+  con <- file(paste(fname, "hdr", sep = "."), "r")
+  l8 <- readLines(con, n = 8)
+  close(con)
+  l8 <- read.dcf(con <- textConnection(gsub(" ", ":", l8)))
+  close(con)
+  lres <- as.list(l8)
+  names(lres) <- colnames(l8)
+  lres$nrows <- as.integer(lres$nrows)
+  lres$ncols <- as.integer(lres$ncols)
+  lres$nbands <- as.integer(lres$nbands)
+  lres$nbits <- as.integer(lres$nbits)
+  lres$skipbytes <- as.integer(lres$skipbytes)
+  lres$nodata <- ifelse(to_int, as.integer(lres$nodata),
+    as.numeric(lres$nodata)
+  )
+  lres$byteorder <- as.character(lres$byteorder)
+  endian <- .Platform$endian
+  if ((endian == "little" && lres$byteorder == "M") ||
+    (endian == "big" && lres$byteorder == "I")) endian <- "swap"
+  con <- file(paste(fname, "wld", sep = "."), "r")
+  l6 <- readLines(con, n = 6)
+  close(con)
+  lres$ewres <- abs(as.numeric(l6[1]))
+  lres$nsres <- abs(as.numeric(l6[4]))
+  lres$n_cc <- as.numeric(l6[6])
+  lres$w_cc <- as.numeric(l6[5])
+  lres$s_cc <- lres$n_cc - lres$nsres * (lres$nrows - 1)
 
-    outres <- numeric(10)
-    outres[1] <- lres$nrows
-    outres[2] <- lres$ncols
-    outres[3] <- lres$nbands
-    outres[4] <- lres$w_cc - (lres$ewres/2)
-    outres[5] <- lres$s_cc - (lres$nsres/2)
-    outres[6] <- lres$ewres
-    outres[7] <- lres$nsres
-    outres[10] <- lres$nbits
-    attr(outres, "endian") <- endian
-    attr(outres, "nodata") <- lres$nodata
-#	grid = GridTopology(c(lres$w_cc, lres$s_cc), 
-#		c(lres$ewres, lres$nsres), c(lres$ncols,lres$nrows))
-    outres
+  outres <- numeric(10)
+  outres[1] <- lres$nrows
+  outres[2] <- lres$ncols
+  outres[3] <- lres$nbands
+  outres[4] <- lres$w_cc - (lres$ewres / 2)
+  outres[5] <- lres$s_cc - (lres$nsres / 2)
+  outres[6] <- lres$ewres
+  outres[7] <- lres$nsres
+  outres[10] <- lres$nbits
+  attr(outres, "endian") <- endian
+  attr(outres, "nodata") <- lres$nodata
+  # 	grid = GridTopology(c(lres$w_cc, lres$s_cc),
+  # 		c(lres$ewres, lres$nsres), c(lres$ncols,lres$nrows))
+  outres
 }
 
 readBinGridData <- function(fname, what, n, size, endian, nodata) {
-    map <- readBin(fname, what=what, n=n, size=size, signed=TRUE,
-	endian=endian)
-    is.na(map) <- map == nodata
-    map
+  map <- readBin(fname,
+    what = what, n = n, size = size, signed = TRUE,
+    endian = endian
+  )
+  is.na(map) <- map == nodata
+  map
 }
 
 repair_cats <- function(x, layer, vname) {
-    if (!(requireNamespace("terra", quietly=TRUE))) 
-        stop("terra required for to repair terra object cats")
-    if (!inherits(x, "SpatRaster")) stop("x not a SpatRaster object")
-    xcats <- getMethod("cats", "SpatRaster")(x)
+  if (!(requireNamespace("terra", quietly = TRUE)))
+    stop("terra required for to repair terra object cats")
+  if (!inherits(x, "SpatRaster")) stop("x not a SpatRaster object")
+  xcats <- getMethod("cats", "SpatRaster")(x)
+  nms <- getMethod("names", "SpatRaster")(x)
+  if (length(xcats) > 1) {
     nms <- getMethod("names", "SpatRaster")(x)
-    if (length(xcats) > 1) {
-        nms <- getMethod("names", "SpatRaster")(x)
-        if (!(layer %in% nms)) stop("layer not found")
-    }
-    xcat <- xcats[[match(layer, nms)]]
-    if (is.null(xcat)) warning("no cats in layer")
-    zcats <- cats_internals(vname)
-    res <- vector(mode="list", length=1)
-    names(res) <- layer
-    res[[1]] <- getMethod("classify", "SpatRaster")(x[[layer]], zcats$rcp_out)
-    getMethod("set.cats", "SpatRaster")(res[[1]], layer=1, value=zcats$levs)
-    getMethod("rast", "list")(res)
+    if (!(layer %in% nms)) stop("layer not found")
+  }
+  xcat <- xcats[[match(layer, nms)]]
+  if (is.null(xcat)) warning("no cats in layer")
+  zcats <- cats_internals(vname)
+  res <- vector(mode = "list", length = 1)
+  names(res) <- layer
+  res[[1]] <- getMethod("classify", "SpatRaster")(x[[layer]], zcats$rcp_out)
+  getMethod("set.cats", "SpatRaster")(res[[1]], layer = 1, value = zcats$levs)
+  getMethod("rast", "list")(res)
 }
 
 cats_internals <- function(vname) {
-    cats <- execGRASS("r.category", map=vname, separator=":", intern=TRUE)
-    cats1 <- strsplit(cats, ":")
-    cats2 <- data.frame(ID=sapply(cats1, "[", 1L), 
-        category=sapply(cats1, "[", 2))
-    cats2$Icat <- as.integer(factor(cats2$category,
-        levels=unique(cats2$category)))
-    cats3 <- split(cats2, cats2$Icat)
-    rcp_out <- do.call("rbind", lapply(cats3, function(x) {
-        cbind(as.integer(x[[1]]), as.integer(x[[3]]))
-    }))
-    levs <- do.call("rbind", lapply(cats3, function(x) {
-        ux <- unique(x[, 2:3])
-        data.frame(cat=as.integer(ux[[2]]), lev=ux[[1]])
-    }))
-    list(rcp_out=rcp_out, levs=levs)
+  cats <- execGRASS("r.category", map = vname, separator = ":", intern = TRUE)
+  cats1 <- strsplit(cats, ":")
+  cats2 <- data.frame(
+    ID = sapply(cats1, "[", 1L),
+    category = sapply(cats1, "[", 2)
+  )
+  cats2$Icat <- as.integer(factor(cats2$category,
+    levels = unique(cats2$category)
+  ))
+  cats3 <- split(cats2, cats2$Icat)
+  rcp_out <- do.call("rbind", lapply(cats3, function(x) {
+    cbind(as.integer(x[[1]]), as.integer(x[[3]]))
+  }))
+  levs <- do.call("rbind", lapply(cats3, function(x) {
+    ux <- unique(x[, 2:3])
+    data.frame(cat = as.integer(ux[[2]]), lev = ux[[1]])
+  }))
+  list(rcp_out = rcp_out, levs = levs)
 }
 
 read_cat_colors <- function(vname) {
-    zcats <- cats_internals(vname)
-    cols <- execGRASS("r.colors.out", map=vname, intern=TRUE)
-    cols12 <- strsplit(cols, " ")
-    cat_col1 <- match(as.character(zcats$rcp_out[,1]), sapply(cols12, "[", 1))
-    if (length(cat_col1) != (length(cols12) - 2L)) 
-        warning("possible category mismatch")
-    coltb <- sapply(cols12[zcats$rcp_out[order(zcats$rcp_out[,1]), 2]], "[", 2L)
-    df <- as.data.frame(t(sapply(strsplit(coltb, ":"), as.integer)))
-    pal <- rgb(df$V1, df$V2, df$V3, maxColorValue=255)
-    list(coltab=df, pal=pal)
+  zcats <- cats_internals(vname)
+  cols <- execGRASS("r.colors.out", map = vname, intern = TRUE)
+  cols12 <- strsplit(cols, " ")
+  cat_col1 <- match(as.character(zcats$rcp_out[, 1]), sapply(cols12, "[", 1))
+  if (length(cat_col1) != (length(cols12) - 2L))
+    warning("possible category mismatch")
+  coltb <- sapply(cols12[zcats$rcp_out[order(zcats$rcp_out[, 1]), 2]], "[", 2L)
+  df <- as.data.frame(t(sapply(strsplit(coltb, ":"), as.integer)))
+  pal <- rgb(df$V1, df$V2, df$V3, maxColorValue = 255)
+  list(coltab = df, pal = pal)
 }
 
 
-write_RAST <- function(x, vname, zcol = 1, NODATA=NULL, flags=NULL, 
-    ignore.stderr = get.ignore.stderrOption(), overwrite=FALSE, verbose=TRUE) {
+write_RAST <- function(
+    x, vname, zcol = 1, NODATA = NULL, flags = NULL,
+    ignore.stderr = get.ignore.stderrOption(), overwrite = FALSE, verbose = TRUE) {
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- set.echoCmdOption(FALSE)
+  }
+  stopifnot(is.logical(ignore.stderr))
+  stopifnot(is.character(vname))
+  if (!is.null(flags)) stopifnot(is.character(flags))
 
-    if (get.suppressEchoCmdInFuncOption()) {
-        inEchoCmd <- set.echoCmdOption(FALSE)
-    }
-    stopifnot(is.logical(ignore.stderr))
-    stopifnot(is.character(vname))
-    if (!is.null(flags)) stopifnot(is.character(flags))
+  if (overwrite && !("overwrite" %in% flags))
+    flags <- c(flags, "overwrite")
+  if (inherits(x, "SpatialGridDataFrame")) {
+    if (!(requireNamespace("sp", quietly = TRUE)))
+      stop("sp required for SGDF input")
+    stopifnot(length(vname) == 1L)
+    pid <- as.integer(round(runif(1, 1, 1000)))
+    gtmpfl1 <- dirname(execGRASS("g.tempfile",
+      pid = pid,
+      intern = TRUE, ignore.stderr = ignore.stderr
+    ))
 
-    if (overwrite && !("overwrite" %in% flags))
-        flags <- c(flags, "overwrite")
-    if (inherits(x, "SpatialGridDataFrame")) {
-        if (!(requireNamespace("sp", quietly=TRUE))) 
-            stop("sp required for SGDF input")
-        stopifnot(length(vname) == 1L)
-        pid <- as.integer(round(runif(1, 1, 1000)))
-        gtmpfl1 <- dirname(execGRASS("g.tempfile", pid=pid,
-            intern=TRUE, ignore.stderr=ignore.stderr))
-                
-        rtmpfl1 <- ifelse(.Platform$OS.type == "windows" &&
-            (Sys.getenv("OSTYPE") == "cygwin"), 
-            system(paste("cygpath -w", gtmpfl1, sep=" "), intern=TRUE), 
-            gtmpfl1)
-                
-        fid <- paste("X", pid, sep="")
-        gtmpfl11 <- paste(gtmpfl1, fid, sep=.Platform$file.sep)
-        rtmpfl11 <- paste(rtmpfl1, fid, sep=.Platform$file.sep)
-        if (!is.numeric(x@data[[zcol]])) 
-            stop("only numeric columns may be exported")
-        res <- writeBinGrid_ng(x, rtmpfl11, attr = zcol, na.value = NODATA)
-                        
-        flags <- c(res$flag, flags)
-                        
-        execGRASS("r.in.bin", flags=flags, input=gtmpfl11, output=vname,
-            bytes=as.integer(res$bytes), north=as.numeric(res$north), 
-            south=as.numeric(res$south), east=as.numeric(res$east), 
-            west=as.numeric(res$west), rows=as.integer(res$rows), 
-            cols=as.integer(res$cols), anull=as.numeric(res$anull), 
-            ignore.stderr=ignore.stderr)
-        if (verbose) message("SpatialGridDataFrame read into GRASS using r.in.bin")
+    rtmpfl1 <- ifelse(.Platform$OS.type == "windows" &&
+      (Sys.getenv("OSTYPE") == "cygwin"),
+    system(paste("cygpath -w", gtmpfl1, sep = " "), intern = TRUE),
+    gtmpfl1
+    )
 
-    } else if (inherits(x, "SpatRaster")) {
-        if (!(requireNamespace("terra", quietly=TRUE))) 
-            stop("terra required for terra output")
-# Suggestion https://github.com/rsbivand/rgrass/pull/45#discussion_r816113064 Floris Vanderhaeghe
-        srcs <- getMethod("sources", "SpatRaster")(x)
-        mems <- getMethod("inMemory", "SpatRaster")(x)
-        if (length(srcs) == 1L && !mems[1]) tf <- srcs[1]
-        else tf <- ""
-        if (!file.exists(tf)) {
-            drv <- "RRASTER"
-            fxt <- ".grd"
-            gdalver <- gsub("[A-Za-z]", "", strsplit(terra::gdal(), "-")[[1]][1])
-            if (gdalver < "2.3.0") {
-                drv <- "GTiff"
-                fxt <- ".tif"
-            }
-            tf <- tempfile(fileext=fxt)
-            res <- getMethod("writeRaster", c("SpatRaster", "character"))(x,
-                filename=tf, overwrite=TRUE, filetype=drv)
-            tmpfl <- TRUE
-        } else {
-            res <- x
-            tmpfl <- FALSE
-        }
-        execGRASS("r.in.gdal", flags=flags, input=tf, output=vname)
-#        if (tmpfl) unlink(tf)
-        if (verbose) message("SpatRaster read into GRASS using r.in.gdal from ",
-            ifelse(tmpfl, "memory", "file"))
-        if (getMethod("nlyr", "SpatRaster")(x) == 1L) {
-            xcats <- getMethod("cats", "SpatRaster")(x)[[1]]
-            if (!is.null(xcats)) {
-                tfc <- tempfile()
-                write.table(xcats, tfc, sep=":", row.names=FALSE, 
-                    col.names=FALSE, quote=FALSE)
-                execGRASS("r.category", map=vname, rules=tfc, separator=":")
-            }
-        }
+    fid <- paste("X", pid, sep = "")
+    gtmpfl11 <- paste(gtmpfl1, fid, sep = .Platform$file.sep)
+    rtmpfl11 <- paste(rtmpfl1, fid, sep = .Platform$file.sep)
+    if (!is.numeric(x@data[[zcol]]))
+      stop("only numeric columns may be exported")
+    res <- writeBinGrid_ng(x, rtmpfl11, attr = zcol, na.value = NODATA)
+
+    flags <- c(res$flag, flags)
+
+    execGRASS("r.in.bin",
+      flags = flags, input = gtmpfl11, output = vname,
+      bytes = as.integer(res$bytes), north = as.numeric(res$north),
+      south = as.numeric(res$south), east = as.numeric(res$east),
+      west = as.numeric(res$west), rows = as.integer(res$rows),
+      cols = as.integer(res$cols), anull = as.numeric(res$anull),
+      ignore.stderr = ignore.stderr
+    )
+    if (verbose) message("SpatialGridDataFrame read into GRASS using r.in.bin")
+  } else if (inherits(x, "SpatRaster")) {
+    if (!(requireNamespace("terra", quietly = TRUE)))
+      stop("terra required for terra output")
+    # Suggestion https://github.com/rsbivand/rgrass/pull/45#discussion_r816113064 Floris Vanderhaeghe
+    srcs <- getMethod("sources", "SpatRaster")(x)
+    mems <- getMethod("inMemory", "SpatRaster")(x)
+    if (length(srcs) == 1L && !mems[1]) tf <- srcs[1]
+    else tf <- ""
+    if (!file.exists(tf)) {
+      drv <- "RRASTER"
+      fxt <- ".grd"
+      gdalver <- gsub("[A-Za-z]", "", strsplit(terra::gdal(), "-")[[1]][1])
+      if (gdalver < "2.3.0") {
+        drv <- "GTiff"
+        fxt <- ".tif"
+      }
+      tf <- tempfile(fileext = fxt)
+      res <- getMethod("writeRaster", c("SpatRaster", "character"))(x,
+        filename = tf, overwrite = TRUE, filetype = drv)
+      tmpfl <- TRUE
     } else {
-        stop("object neither SpatialGridDataFrame nor SpatRaster")
+      res <- x
+      tmpfl <- FALSE
     }
-    if (get.suppressEchoCmdInFuncOption()) {
-        tull <- set.echoCmdOption(inEchoCmd)
+    execGRASS("r.in.gdal", flags = flags, input = tf, output = vname)
+    #        if (tmpfl) unlink(tf)
+    if (verbose) message(
+      "SpatRaster read into GRASS using r.in.gdal from ",
+      ifelse(tmpfl, "memory", "file")
+    )
+    if (getMethod("nlyr", "SpatRaster")(x) == 1L) {
+      xcats <- getMethod("cats", "SpatRaster")(x)[[1]]
+      if (!is.null(xcats)) {
+        tfc <- tempfile()
+        write.table(xcats, tfc,
+          sep = ":", row.names = FALSE,
+          col.names = FALSE, quote = FALSE
+        )
+        execGRASS("r.category", map = vname, rules = tfc, separator = ":")
+      }
     }
-    invisible(res)
+  } else {
+    stop("object neither SpatialGridDataFrame nor SpatRaster")
+  }
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  invisible(res)
 }
 
-writeBinGrid_ng <- function(x, fname, attr = 1, na.value = NULL) { 
-	if (!sp::gridded(x))
-		stop("can only write SpatialGridDataFrame objects to binary grid")
-	x = as(x, "SpatialGridDataFrame")
-	gp = sp::gridparameters(x)
-	if (length(gp$cells.dim) != 2)
-		stop("binary grid only supports 2D grids")
-	z = x@data[[attr]]
-	if (is.factor(z)) z <- as.numeric(z)
-	if (!is.numeric(z)) stop("only numeric values may be exported")
-	if (is.null(na.value)) {
-		na.value <- floor(min(z, na.rm=TRUE)) - 1
-	} else {
-		if (!is.finite(na.value) || !is.numeric(na.value))
-			stop("invalid NODATA value")
-		if (na.value != round(na.value)) 
-			warning("NODATA rounded to integer")
-		na.value <- round(na.value)
-	}
-	res <- list()
-	res$anull <- formatC(na.value, format="d")
-	z[is.na(z)] = as.integer(na.value)
-	if (storage.mode(z) == "integer") {
-		sz <- 4
-	} else if (storage.mode(z) == "double") {
-		sz <- 8
-		res$flag <- "d"
-	} else stop("unknown storage mode")
-	res$bytes <- formatC(sz, format="d")
-	f = file(fname, open = "wb")
-	writeBin(z, con=f, size=sz)
-	close(f)
-	grd <- slot(x, "grid")
-	f = file(paste(fname, "hdr", sep="."), open = "wt")
-	writeLines(paste("nrows", grd@cells.dim[2]), f)
-	res$rows <- formatC(grd@cells.dim[2], format="d")
-	writeLines(paste("ncols", grd@cells.dim[1]), f)
-	res$cols <- formatC(grd@cells.dim[1], format="d")
-	writeLines(paste("nbands 1"), f)
-	writeLines(paste("nbits", 8*sz), f)
-	writeLines(paste("byteorder", ifelse(.Platform$endian == "little", 
-		"I", "M")), f)
-	writeLines(paste("layout bil"), f)
-	writeLines(paste("skipbytes 0"), f)
-	writeLines(paste("nodata", na.value), f)
-	close(f)
-	f = file(paste(fname, "wld", sep="."), open = "wt")
-	writeLines(formatC(grd@cellsize[1], format="f"), f)
-	writeLines("0.0", f)
-	writeLines("0.0", f)
-	writeLines(formatC(-grd@cellsize[2], format="f"), f)
-	writeLines(formatC(grd@cellcentre.offset[1], format="f"), f)
-	writeLines(formatC((grd@cellcentre.offset[2] +
-		grd@cellsize[2]*(grd@cells.dim[2]-1)), format="f"), f)
-	close(f)
-	res$north <- formatC((grd@cellcentre.offset[2] +
-		grd@cellsize[2]*(grd@cells.dim[2]-1)
-		+ 0.5*grd@cellsize[2]), format="f")
-	res$south <- formatC(grd@cellcentre.offset[2] - 0.5*grd@cellsize[2], 
-		format="f")
-	res$east <- formatC((grd@cellcentre.offset[1] + 
-		grd@cellsize[1]*(grd@cells.dim[1]-1) + 0.5*grd@cellsize[1]), 
-		format="f")
-	res$west <- formatC(grd@cellcentre.offset[1] - 0.5*grd@cellsize[1], 
-		format="f")
-	invisible(res)
+writeBinGrid_ng <- function(x, fname, attr = 1, na.value = NULL) {
+  if (!sp::gridded(x))
+    stop("can only write SpatialGridDataFrame objects to binary grid")
+  x = as(x, "SpatialGridDataFrame")
+  gp = sp::gridparameters(x)
+  if (length(gp$cells.dim) != 2)
+    stop("binary grid only supports 2D grids")
+  z = x@data[[attr]]
+  if (is.factor(z)) z <- as.numeric(z)
+  if (!is.numeric(z)) stop("only numeric values may be exported")
+  if (is.null(na.value)) {
+    na.value <- floor(min(z, na.rm = TRUE)) - 1
+  } else {
+    if (!is.finite(na.value) || !is.numeric(na.value))
+      stop("invalid NODATA value")
+    if (na.value != round(na.value))
+      warning("NODATA rounded to integer")
+    na.value <- round(na.value)
+  }
+  res <- list()
+  res$anull <- formatC(na.value, format = "d")
+  z[is.na(z)] = as.integer(na.value)
+  if (storage.mode(z) == "integer") {
+    sz <- 4
+  } else if (storage.mode(z) == "double") {
+    sz <- 8
+    res$flag <- "d"
+  } else stop("unknown storage mode")
+  res$bytes <- formatC(sz, format = "d")
+  f = file(fname, open = "wb")
+  writeBin(z, con = f, size = sz)
+  close(f)
+  grd <- slot(x, "grid")
+  f = file(paste(fname, "hdr", sep = "."), open = "wt")
+  writeLines(paste("nrows", grd@cells.dim[2]), f)
+  res$rows <- formatC(grd@cells.dim[2], format = "d")
+  writeLines(paste("ncols", grd@cells.dim[1]), f)
+  res$cols <- formatC(grd@cells.dim[1], format = "d")
+  writeLines(paste("nbands 1"), f)
+  writeLines(paste("nbits", 8 * sz), f)
+  writeLines(paste("byteorder", ifelse(.Platform$endian == "little",
+    "I", "M"
+  )), f)
+  writeLines(paste("layout bil"), f)
+  writeLines(paste("skipbytes 0"), f)
+  writeLines(paste("nodata", na.value), f)
+  close(f)
+  f = file(paste(fname, "wld", sep = "."), open = "wt")
+  writeLines(formatC(grd@cellsize[1], format = "f"), f)
+  writeLines("0.0", f)
+  writeLines("0.0", f)
+  writeLines(formatC(-grd@cellsize[2], format = "f"), f)
+  writeLines(formatC(grd@cellcentre.offset[1], format = "f"), f)
+  writeLines(formatC((grd@cellcentre.offset[2] +
+    grd@cellsize[2] * (grd@cells.dim[2] - 1)), format = "f"), f)
+  close(f)
+  res$north <- formatC((grd@cellcentre.offset[2] +
+    grd@cellsize[2] * (grd@cells.dim[2] - 1)
+    + 0.5 * grd@cellsize[2]), format = "f")
+  res$south <- formatC(grd@cellcentre.offset[2] - 0.5 * grd@cellsize[2],
+    format = "f"
+  )
+  res$east <- formatC(
+    (grd@cellcentre.offset[1] +
+      grd@cellsize[1] * (grd@cells.dim[1] - 1) + 0.5 * grd@cellsize[1]),
+    format = "f"
+  )
+  res$west <- formatC(grd@cellcentre.offset[1] - 0.5 * grd@cellsize[1],
+    format = "f"
+  )
+  invisible(res)
 }
-

--- a/R/rast_link.R
+++ b/R/rast_link.R
@@ -6,9 +6,11 @@ read_RAST <- function(
     vname, cat = NULL, NODATA = NULL,
     ignore.stderr = get.ignore.stderrOption(), return_format = "terra",
     close_OK = return_format == "SGDF", flags = NULL) {
-  if (!is.null(cat))
-    if (length(vname) != length(cat))
+  if (!is.null(cat)) {
+    if (length(vname) != length(cat)) {
       stop("vname and cat not same length")
+    }
+  }
   if (get.suppressEchoCmdInFuncOption()) {
     inEchoCmd <- set.echoCmdOption(FALSE)
   }
@@ -18,13 +20,16 @@ read_RAST <- function(
   stopifnot(is.logical(ignore.stderr))
 
   if (!is.null(NODATA)) {
-    if (any(!is.finite(NODATA)) || any(!is.numeric(NODATA)))
+    if (any(!is.finite(NODATA)) || any(!is.numeric(NODATA))) {
       stop("invalid NODATA value")
-    if (NODATA != round(NODATA))
+    }
+    if (NODATA != round(NODATA)) {
       warning("NODATA rounded to integer")
+    }
     NODATA <- round(NODATA)
-    if (length(NODATA) != length(vname))
+    if (length(NODATA) != length(vname)) {
       NODATA <- rep(NODATA[1], length.out = length(vname))
+    }
   }
 
   msp <- unlist(strsplit(execGRASS("g.mapsets",
@@ -33,8 +38,9 @@ read_RAST <- function(
   ), " "))
 
   if (return_format == "SGDF") {
-    if (!(requireNamespace("sp", quietly = TRUE)))
+    if (!(requireNamespace("sp", quietly = TRUE))) {
       stop("sp required for SGDF output")
+    }
     resa <- .read_rast_non_plugin_ng(
       vname = vname, cat = cat, NODATA = NODATA,
       ignore.stderr = ignore.stderr
@@ -45,8 +51,9 @@ read_RAST <- function(
       for (bye in toBeClosed) close(bye)
     }
   } else {
-    if (!(requireNamespace("terra", quietly = TRUE)))
+    if (!(requireNamespace("terra", quietly = TRUE))) {
       stop("terra required for SpatRaster output")
+    }
     drv <- "RRASTER"
     fxt <- ".grd"
     ro <- FALSE
@@ -76,25 +83,31 @@ read_RAST <- function(
           type = "raster", pattern = vca[1],
           intern = TRUE, ignore.stderr = ignore.stderr
         )
-        if (length(exsts) > 1L) stop(
-          "multiple rasters named ", vca[1],
-          " found in in mapsets in search path: ",
-          paste(msp, collapse = ", "),
-          " ; use full path with @ to choose the required raster"
-        )
-        if (length(exsts) == 0L || exsts != vca[1])
+        if (length(exsts) > 1L) {
+          stop(
+            "multiple rasters named ", vca[1],
+            " found in in mapsets in search path: ",
+            paste(msp, collapse = ", "),
+            " ; use full path with @ to choose the required raster"
+          )
+        }
+        if (length(exsts) == 0L || exsts != vca[1]) {
           stop(
             vname[i], " not found in mapsets in search path: ",
             paste(msp, collapse = ", ")
           )
+        }
       } else if (length(vca) == 2L) {
         exsts <- execGRASS("g.list",
           type = "raster", pattern = vca[1],
           mapset = vca[2], intern = TRUE, ignore.stderr = ignore.stderr
         )
-        if (length(exsts) == 0L || exsts != vca[1])
+        if (length(exsts) == 0L || exsts != vca[1]) {
           stop(vname[i], " not found in mapset: ", vca[2])
-      } else stop(vname[i], " incorrectly formatted")
+        }
+      } else {
+        stop(vname[i], " incorrectly formatted")
+      }
       typei <- NULL
       if (is.null(NODATA)) {
         tx <- execGRASS("r.info",
@@ -107,8 +120,9 @@ read_RAST <- function(
         close(con)
         lres <- as.list(res)
         names(lres) <- colnames(res)
-        lres <- lapply(lres, function(x)
-          ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
+        lres <- lapply(lres, function(x) {
+          ifelse(x == "NULL", as.numeric(NA), as.numeric(x))
+        })
         tx <- execGRASS("r.info",
           flags = "g", map = vname[i], intern = TRUE,
           ignore.stderr = ignore.stderr
@@ -163,20 +177,26 @@ read_RAST <- function(
               if (lres$max < 2147483647) {
                 NODATAi <- 2147483647
                 typei <- "Int32"
-              } else stop("set NODATA manually to a feasible value")
+              } else {
+                stop("set NODATA manually to a feasible value")
+              }
             }
             if (lres$min == -32768) {
               if (lres$max < 32767) {
                 NODATAi <- 32767
                 typei <- "Int16"
-              } else stop("set NODATA manually to a feasible value")
+              } else {
+                stop("set NODATA manually to a feasible value")
+              }
             }
             if (is.null(NODATAi)) NODATAi <- floor(lres$min) - 1
           } else {
             NODATAi <- floor(lres$min) - 1
           }
         }
-      } else NODATAi <- NODATA[i]
+      } else {
+        NODATAi <- NODATA[i]
+      }
       tmplist[[i]] <- tempfile(fileext = fxt)
       if (is.null(flags)) flags <- c("overwrite", "c", "m")
       if (!is.null(cat) && cat[i]) flags <- c(flags, "t")
@@ -207,10 +227,11 @@ read_RAST <- function(
   pid <- as.integer(round(runif(1, 1, 1000)))
 
   gLP <- getLocationProj()
-  if (gLP == "XY location (unprojected)")
+  if (gLP == "XY location (unprojected)") {
     p4 <- sp::CRS(as.character(NA))
-  else
+  } else {
     p4 <- sp::CRS(gLP)
+  }
 
   reslist <- vector(mode = "list", length = length(vname))
   names(reslist) <- gsub("@", "_", vname)
@@ -227,25 +248,31 @@ read_RAST <- function(
         type = "raster", pattern = vca[1],
         intern = TRUE, ignore.stderr = ignore.stderr
       )
-      if (length(exsts) > 1L) stop(
-        "multiple rasters named ", vca[1],
-        " found in in mapsets in search path:\n",
-        paste(msp, collapse = ", "),
-        "\nuse full path with @ to choose the required raster"
-      )
-      if (length(exsts) == 0L || exsts != vca[1])
+      if (length(exsts) > 1L) {
+        stop(
+          "multiple rasters named ", vca[1],
+          " found in in mapsets in search path:\n",
+          paste(msp, collapse = ", "),
+          "\nuse full path with @ to choose the required raster"
+        )
+      }
+      if (length(exsts) == 0L || exsts != vca[1]) {
         stop(
           vname[i], " not found in mapsets in search path: ",
           paste(msp, collapse = ", ")
         )
+      }
     } else if (length(vca) == 2L) {
       exsts <- execGRASS("g.list",
         type = "raster", pattern = vca[1],
         mapset = vca[2], intern = TRUE, ignore.stderr = ignore.stderr
       )
-      if (length(exsts) == 0L || exsts != vca[1])
+      if (length(exsts) == 0L || exsts != vca[1]) {
         stop(vname[i], " not found in mapset: ", vca[2])
-    } else stop(vname[i], " incorrectly formatted")
+      }
+    } else {
+      stop(vname[i], " incorrectly formatted")
+    }
     glist <- execGRASS("r.info",
       flags = "g", map = vname[i],
       intern = TRUE, ignore.stderr = ignore.stderr
@@ -284,12 +311,13 @@ read_RAST <- function(
       close(con)
       lres <- as.list(res)
       names(lres) <- colnames(res)
-      lres <- lapply(lres, function(x)
-        ifelse(x == "NULL", as.numeric(NA), as.numeric(x)))
+      lres <- lapply(lres, function(x) {
+        ifelse(x == "NULL", as.numeric(NA), as.numeric(x))
+      })
       if (!is.numeric(lres$min) ||
-        !is.finite(as.double(lres$min)))
+        !is.finite(as.double(lres$min))) {
         NODATAi <- as.integer(999)
-      else {
+      } else {
         lres$min <- floor(as.double(lres$min))
         NODATAi <- floor(lres$min) - 1
       }
@@ -297,8 +325,11 @@ read_RAST <- function(
 
     rOutBinFlags <- "b"
     # 120118 Rainer Krug
-    if (to_int) rOutBinFlags <- c(rOutBinFlags, "i")
-    else rOutBinFlags <- c(rOutBinFlags, "f")
+    if (to_int) {
+      rOutBinFlags <- c(rOutBinFlags, "i")
+    } else {
+      rOutBinFlags <- c(rOutBinFlags, "f")
+    }
     rOutBinBytes <- 4L
     if (Dcell) rOutBinBytes <- 8L
     tryCatch({
@@ -335,8 +366,9 @@ read_RAST <- function(
     unname(c(gdal_info[2], gdal_info[1]))
   )
 
-  if (length(unique(sapply(reslist, length))) != 1)
+  if (length(unique(sapply(reslist, length))) != 1) {
     stop("bands differ in length")
+  }
 
   df <- as.data.frame(reslist)
 
@@ -381,10 +413,12 @@ read_RAST <- function(
 
 bin_gdal_info_ng <- function(fname, to_int) {
   if (!file.exists(fname)) stop(paste("no such file:", fname))
-  if (!file.exists(paste(fname, "hdr", sep = ".")))
+  if (!file.exists(paste(fname, "hdr", sep = "."))) {
     stop(paste("no such file:", paste(fname, "hdr", sep = ".")))
-  if (!file.exists(paste(fname, "wld", sep = ".")))
+  }
+  if (!file.exists(paste(fname, "wld", sep = "."))) {
     stop(paste("no such file:", paste(fname, "wld", sep = ".")))
+  }
   con <- file(paste(fname, "hdr", sep = "."), "r")
   l8 <- readLines(con, n = 8)
   close(con)
@@ -403,7 +437,9 @@ bin_gdal_info_ng <- function(fname, to_int) {
   lres$byteorder <- as.character(lres$byteorder)
   endian <- .Platform$endian
   if ((endian == "little" && lres$byteorder == "M") ||
-    (endian == "big" && lres$byteorder == "I")) endian <- "swap"
+    (endian == "big" && lres$byteorder == "I")) {
+    endian <- "swap"
+  }
   con <- file(paste(fname, "wld", sep = "."), "r")
   l6 <- readLines(con, n = 6)
   close(con)
@@ -439,8 +475,9 @@ readBinGridData <- function(fname, what, n, size, endian, nodata) {
 }
 
 repair_cats <- function(x, layer, vname) {
-  if (!(requireNamespace("terra", quietly = TRUE)))
+  if (!(requireNamespace("terra", quietly = TRUE))) {
     stop("terra required for to repair terra object cats")
+  }
   if (!inherits(x, "SpatRaster")) stop("x not a SpatRaster object")
   xcats <- getMethod("cats", "SpatRaster")(x)
   nms <- getMethod("names", "SpatRaster")(x)
@@ -484,8 +521,9 @@ read_cat_colors <- function(vname) {
   cols <- execGRASS("r.colors.out", map = vname, intern = TRUE)
   cols12 <- strsplit(cols, " ")
   cat_col1 <- match(as.character(zcats$rcp_out[, 1]), sapply(cols12, "[", 1))
-  if (length(cat_col1) != (length(cols12) - 2L))
+  if (length(cat_col1) != (length(cols12) - 2L)) {
     warning("possible category mismatch")
+  }
   coltb <- sapply(cols12[zcats$rcp_out[order(zcats$rcp_out[, 1]), 2]], "[", 2L)
   df <- as.data.frame(t(sapply(strsplit(coltb, ":"), as.integer)))
   pal <- rgb(df$V1, df$V2, df$V3, maxColorValue = 255)
@@ -503,11 +541,13 @@ write_RAST <- function(
   stopifnot(is.character(vname))
   if (!is.null(flags)) stopifnot(is.character(flags))
 
-  if (overwrite && !("overwrite" %in% flags))
+  if (overwrite && !("overwrite" %in% flags)) {
     flags <- c(flags, "overwrite")
+  }
   if (inherits(x, "SpatialGridDataFrame")) {
-    if (!(requireNamespace("sp", quietly = TRUE)))
+    if (!(requireNamespace("sp", quietly = TRUE))) {
       stop("sp required for SGDF input")
+    }
     stopifnot(length(vname) == 1L)
     pid <- as.integer(round(runif(1, 1, 1000)))
     gtmpfl1 <- dirname(execGRASS("g.tempfile",
@@ -524,8 +564,9 @@ write_RAST <- function(
     fid <- paste("X", pid, sep = "")
     gtmpfl11 <- paste(gtmpfl1, fid, sep = .Platform$file.sep)
     rtmpfl11 <- paste(rtmpfl1, fid, sep = .Platform$file.sep)
-    if (!is.numeric(x@data[[zcol]]))
+    if (!is.numeric(x@data[[zcol]])) {
       stop("only numeric columns may be exported")
+    }
     res <- writeBinGrid_ng(x, rtmpfl11, attr = zcol, na.value = NODATA)
 
     flags <- c(res$flag, flags)
@@ -540,13 +581,17 @@ write_RAST <- function(
     )
     if (verbose) message("SpatialGridDataFrame read into GRASS using r.in.bin")
   } else if (inherits(x, "SpatRaster")) {
-    if (!(requireNamespace("terra", quietly = TRUE)))
+    if (!(requireNamespace("terra", quietly = TRUE))) {
       stop("terra required for terra output")
+    }
     # Suggestion https://github.com/rsbivand/rgrass/pull/45#discussion_r816113064 Floris Vanderhaeghe
     srcs <- getMethod("sources", "SpatRaster")(x)
     mems <- getMethod("inMemory", "SpatRaster")(x)
-    if (length(srcs) == 1L && !mems[1]) tf <- srcs[1]
-    else tf <- ""
+    if (length(srcs) == 1L && !mems[1]) {
+      tf <- srcs[1]
+    } else {
+      tf <- ""
+    }
     if (!file.exists(tf)) {
       drv <- "RRASTER"
       fxt <- ".grd"
@@ -565,10 +610,12 @@ write_RAST <- function(
     }
     execGRASS("r.in.gdal", flags = flags, input = tf, output = vname)
     #        if (tmpfl) unlink(tf)
-    if (verbose) message(
-      "SpatRaster read into GRASS using r.in.gdal from ",
-      ifelse(tmpfl, "memory", "file")
-    )
+    if (verbose) {
+      message(
+        "SpatRaster read into GRASS using r.in.gdal from ",
+        ifelse(tmpfl, "memory", "file")
+      )
+    }
     if (getMethod("nlyr", "SpatRaster")(x) == 1L) {
       xcats <- getMethod("cats", "SpatRaster")(x)[[1]]
       if (!is.null(xcats)) {
@@ -590,39 +637,45 @@ write_RAST <- function(
 }
 
 writeBinGrid_ng <- function(x, fname, attr = 1, na.value = NULL) {
-  if (!sp::gridded(x))
+  if (!sp::gridded(x)) {
     stop("can only write SpatialGridDataFrame objects to binary grid")
-  x = as(x, "SpatialGridDataFrame")
-  gp = sp::gridparameters(x)
-  if (length(gp$cells.dim) != 2)
+  }
+  x <- as(x, "SpatialGridDataFrame")
+  gp <- sp::gridparameters(x)
+  if (length(gp$cells.dim) != 2) {
     stop("binary grid only supports 2D grids")
-  z = x@data[[attr]]
+  }
+  z <- x@data[[attr]]
   if (is.factor(z)) z <- as.numeric(z)
   if (!is.numeric(z)) stop("only numeric values may be exported")
   if (is.null(na.value)) {
     na.value <- floor(min(z, na.rm = TRUE)) - 1
   } else {
-    if (!is.finite(na.value) || !is.numeric(na.value))
+    if (!is.finite(na.value) || !is.numeric(na.value)) {
       stop("invalid NODATA value")
-    if (na.value != round(na.value))
+    }
+    if (na.value != round(na.value)) {
       warning("NODATA rounded to integer")
+    }
     na.value <- round(na.value)
   }
   res <- list()
   res$anull <- formatC(na.value, format = "d")
-  z[is.na(z)] = as.integer(na.value)
+  z[is.na(z)] <- as.integer(na.value)
   if (storage.mode(z) == "integer") {
     sz <- 4
   } else if (storage.mode(z) == "double") {
     sz <- 8
     res$flag <- "d"
-  } else stop("unknown storage mode")
+  } else {
+    stop("unknown storage mode")
+  }
   res$bytes <- formatC(sz, format = "d")
-  f = file(fname, open = "wb")
+  f <- file(fname, open = "wb")
   writeBin(z, con = f, size = sz)
   close(f)
   grd <- slot(x, "grid")
-  f = file(paste(fname, "hdr", sep = "."), open = "wt")
+  f <- file(paste(fname, "hdr", sep = "."), open = "wt")
   writeLines(paste("nrows", grd@cells.dim[2]), f)
   res$rows <- formatC(grd@cells.dim[2], format = "d")
   writeLines(paste("ncols", grd@cells.dim[1]), f)
@@ -636,7 +689,7 @@ writeBinGrid_ng <- function(x, fname, attr = 1, na.value = NULL) {
   writeLines(paste("skipbytes 0"), f)
   writeLines(paste("nodata", na.value), f)
   close(f)
-  f = file(paste(fname, "wld", sep = "."), open = "wt")
+  f <- file(paste(fname, "wld", sep = "."), open = "wt")
   writeLines(formatC(grd@cellsize[1], format = "f"), f)
   writeLines("0.0", f)
   writeLines("0.0", f)

--- a/R/rgrass.R
+++ b/R/rgrass.R
@@ -28,19 +28,31 @@ gmeta <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
   lres$ewres <- as.double(lres$ewres)
   lres$ewres3 <- as.double(lres$ewres3)
   lres$tbres <- as.double(lres$tbres)
-  if (length(lres$rows) == 0)
+  if (length(lres$rows) == 0) {
     lres$rows <- abs(as.integer((lres$n - lres$s) / lres$nsres))
-  else lres$rows <- as.integer(lres$rows)
-  if (length(lres$rows3) == 0) lres$rows3 <- lres$rows
-  else lres$rows3 <- as.integer(lres$rows3)
-  if (length(lres$cols) == 0)
+  } else {
+    lres$rows <- as.integer(lres$rows)
+  }
+  if (length(lres$rows3) == 0) {
+    lres$rows3 <- lres$rows
+  } else {
+    lres$rows3 <- as.integer(lres$rows3)
+  }
+  if (length(lres$cols) == 0) {
     lres$cols <- abs(as.integer((lres$e - lres$w) / lres$ewres))
-  else lres$cols <- as.integer(lres$cols)
-  if (length(lres$cols3) == 0) lres$cols3 <- lres$cols
-  else lres$cols3 <- as.integer(lres$cols3)
-  if (length(lres$depths) == 0)
+  } else {
+    lres$cols <- as.integer(lres$cols)
+  }
+  if (length(lres$cols3) == 0) {
+    lres$cols3 <- lres$cols
+  } else {
+    lres$cols3 <- as.integer(lres$cols3)
+  }
+  if (length(lres$depths) == 0) {
     lres$depths <- abs(as.integer((lres$t - lres$b) / lres$tbres))
-  else lres$depths <- as.integer(lres$depths)
+  } else {
+    lres$depths <- as.integer(lres$depths)
+  }
   lres$proj4 <- ""
   prj <- try(getLocationProj(
     g.proj_WKT = g.proj_WKT,
@@ -75,16 +87,20 @@ print.gmeta <- function(x, ...) {
   cat("east       ", x$e, "\n")
   cat("nsres      ", x$nsres, "\n")
   cat("ewres      ", x$ewres, "\n")
-  if (is.character(x$proj4[1]) && nzchar(x$proj4[1]))
-    if (substr(x$proj4[1], 1, 1) == "+")
+  if (is.character(x$proj4[1]) && nzchar(x$proj4[1])) {
+    if (substr(x$proj4[1], 1, 1) == "+") {
       cat("projection ", paste(strwrap(x$proj4), collapse = "\n"), "\n")
-    else cat("projection:\n", x$proj4[1], "\n")
+    } else {
+      cat("projection:\n", x$proj4[1], "\n")
+    }
+  }
   invisible(x)
 }
 
 gmeta2grd <- function(ignore.stderr = FALSE) {
-  if (!requireNamespace("sp", quietly = TRUE))
+  if (!requireNamespace("sp", quietly = TRUE)) {
     stop("sp required to creat a GridTopology object")
+  }
   G <- gmeta(ignore.stderr = ignore.stderr)
   cellcentre.offset <- c(G$w + (G$ewres / 2), G$s + (G$nsres / 2))
   cellsize <- c(G$ewres, G$nsres)
@@ -108,13 +124,15 @@ getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
   gv <- .grassVersion()
   WKT2 <- gv >= "GRASS 7.6"
   old_proj <- TRUE
-  if (requireNamespace("terra", quietly = TRUE))
+  if (requireNamespace("terra", quietly = TRUE)) {
     old_proj <- as.integer(substring(terra::gdal(lib = "proj"), 1, 1)) <= 5L
+  }
   if (!is.null(g.proj_WKT)) {
     stopifnot(is.logical(g.proj_WKT))
     stopifnot(length(g.proj_WKT) == 1L)
-    if (gv < "GRASS 7.6" || g.proj_WKT)
+    if (gv < "GRASS 7.6" || g.proj_WKT) {
       warning("Only Proj4 string representation for GRASS < 7.6")
+    }
     if (!g.proj_WKT) WKT2 <- FALSE
   }
   if (WKT2 && !old_proj) {
@@ -136,14 +154,19 @@ getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
     flags = c("j", "f"), intern = TRUE,
     ignore.stderr = ignore.stderr
   )
-  if (length(grep("XY location", projstr)) > 0)
+  if (length(grep("XY location", projstr)) > 0) {
     projstr <- as.character(NA)
-  if (length(grep("latlong", projstr)) > 0)
+  }
+  if (length(grep("latlong", projstr)) > 0) {
     projstr <- sub("latlong", "longlat", projstr)
-  if (is.na(projstr)) uprojargs <- projstr
-  else uprojargs <- paste(unique(unlist(strsplit(projstr, " "))),
-    collapse = " "
-  )
+  }
+  if (is.na(projstr)) {
+    uprojargs <- projstr
+  } else {
+    uprojargs <- paste(unique(unlist(strsplit(projstr, " "))),
+      collapse = " "
+    )
+  }
   if (length(grep("= ", uprojargs)) != 0) {
     warning(paste(
       "No spaces permitted in PROJ4",
@@ -175,8 +198,9 @@ getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
   close(con)
   lres <- as.list(res)
   names(lres) <- colnames(res)
-  if (nchar(lres$name) == 0)
+  if (nchar(lres$name) == 0) {
     stop(paste(vname[1], "- file not found"))
+  }
   mapset <- gsub("'", "", lres$mapset)
   mapset
 }
@@ -186,7 +210,7 @@ getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
 .addexe <- function() {
   res <- ""
   SYS <- get("SYS", envir = .GRASS_CACHE)
-  if (SYS == "WinNat") res = ".exe"
+  if (SYS == "WinNat") res <- ".exe"
   res
 }
 
@@ -197,8 +221,9 @@ getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
     intern = TRUE,
     ignore.stderr = ignore.stderr
   ), silent = TRUE)
-  if (inherits(Gver, "try-error"))
+  if (inherits(Gver, "try-error")) {
     Gver <- "sh: line 1: g.version: command not found"
+  }
   return(Gver)
 }
 

--- a/R/rgrass.R
+++ b/R/rgrass.R
@@ -2,206 +2,226 @@
 # Copyright (c) 2015-20 Roger S. Bivand
 #
 
-gmeta <- function(ignore.stderr = FALSE, g.proj_WKT=NULL) {
-        if (get.suppressEchoCmdInFuncOption()) {
-            inEchoCmd <- get.echoCmdOption()
-             tull <- set.echoCmdOption(FALSE)
-        }
-        tx <- execGRASS("g.region", flags=c("g", "3"), intern=TRUE,
-            ignore.stderr=ignore.stderr)
-	tx <- gsub("=", ":", tx)
-	con <- textConnection(tx)
-	res <- read.dcf(con)
-	close(con)
-	lres <- as.list(res)
-	names(lres) <- colnames(res)
-	lres$n <- as.double(lres$n)
-	lres$s <- as.double(lres$s)
-	lres$w <- as.double(lres$w)
-	lres$e <- as.double(lres$e)
-	lres$t <- as.double(lres$t)
-	lres$b <- as.double(lres$b)
-	lres$nsres <- as.double(lres$nsres)
-	lres$nsres3 <- as.double(lres$nsres3)
-	lres$ewres <- as.double(lres$ewres)
-	lres$ewres3 <- as.double(lres$ewres3)
-	lres$tbres <- as.double(lres$tbres)
-	if (length(lres$rows) == 0) 
-		lres$rows <- abs(as.integer((lres$n-lres$s)/lres$nsres))
-	else lres$rows <- as.integer(lres$rows)
-	if (length(lres$rows3) == 0) lres$rows3 <- lres$rows
-	else lres$rows3 <- as.integer(lres$rows3)
-	if (length(lres$cols) == 0) 
-		lres$cols <- abs(as.integer((lres$e-lres$w)/lres$ewres))
-	else lres$cols <- as.integer(lres$cols)
-	if (length(lres$cols3) == 0) lres$cols3 <- lres$cols
-	else lres$cols3 <- as.integer(lres$cols3)
-	if (length(lres$depths) == 0) 
-		lres$depths <- abs(as.integer((lres$t-lres$b)/lres$tbres))
-	else lres$depths <- as.integer(lres$depths)
-        lres$proj4 <- ""
-        prj <- try(getLocationProj(g.proj_WKT=g.proj_WKT,
-            ignore.stderr=ignore.stderr), silent=TRUE)
-	if (!inherits(prj, "try-error")) lres$proj4 <- prj
-        gisenv <- execGRASS("g.gisenv", flags="n", intern=TRUE,
-            ignore.stderr=ignore.stderr)
-	gisenv <- gsub("[';]", "", gisenv)
-	gisenv <- strsplit(gisenv, "=")
-	glist <- as.list(sapply(gisenv, function(x) x[2]))
-	names(glist) <- sapply(gisenv, function(x) x[1])
-	lres <- c(glist, lres)
-	class(lres) <- "gmeta"
-        if (get.suppressEchoCmdInFuncOption()) {
-            tull <- set.echoCmdOption(inEchoCmd)
-        }
-	lres
+gmeta <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- get.echoCmdOption()
+    tull <- set.echoCmdOption(FALSE)
+  }
+  tx <- execGRASS("g.region",
+    flags = c("g", "3"), intern = TRUE,
+    ignore.stderr = ignore.stderr
+  )
+  tx <- gsub("=", ":", tx)
+  con <- textConnection(tx)
+  res <- read.dcf(con)
+  close(con)
+  lres <- as.list(res)
+  names(lres) <- colnames(res)
+  lres$n <- as.double(lres$n)
+  lres$s <- as.double(lres$s)
+  lres$w <- as.double(lres$w)
+  lres$e <- as.double(lres$e)
+  lres$t <- as.double(lres$t)
+  lres$b <- as.double(lres$b)
+  lres$nsres <- as.double(lres$nsres)
+  lres$nsres3 <- as.double(lres$nsres3)
+  lres$ewres <- as.double(lres$ewres)
+  lres$ewres3 <- as.double(lres$ewres3)
+  lres$tbres <- as.double(lres$tbres)
+  if (length(lres$rows) == 0)
+    lres$rows <- abs(as.integer((lres$n - lres$s) / lres$nsres))
+  else lres$rows <- as.integer(lres$rows)
+  if (length(lres$rows3) == 0) lres$rows3 <- lres$rows
+  else lres$rows3 <- as.integer(lres$rows3)
+  if (length(lres$cols) == 0)
+    lres$cols <- abs(as.integer((lres$e - lres$w) / lres$ewres))
+  else lres$cols <- as.integer(lres$cols)
+  if (length(lres$cols3) == 0) lres$cols3 <- lres$cols
+  else lres$cols3 <- as.integer(lres$cols3)
+  if (length(lres$depths) == 0)
+    lres$depths <- abs(as.integer((lres$t - lres$b) / lres$tbres))
+  else lres$depths <- as.integer(lres$depths)
+  lres$proj4 <- ""
+  prj <- try(getLocationProj(
+    g.proj_WKT = g.proj_WKT,
+    ignore.stderr = ignore.stderr
+  ), silent = TRUE)
+  if (!inherits(prj, "try-error")) lres$proj4 <- prj
+  gisenv <- execGRASS("g.gisenv",
+    flags = "n", intern = TRUE,
+    ignore.stderr = ignore.stderr
+  )
+  gisenv <- gsub("[';]", "", gisenv)
+  gisenv <- strsplit(gisenv, "=")
+  glist <- as.list(sapply(gisenv, function(x) x[2]))
+  names(glist) <- sapply(gisenv, function(x) x[1])
+  lres <- c(glist, lres)
+  class(lres) <- "gmeta"
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  lres
 }
 
 print.gmeta <- function(x, ...) {
-    cat("gisdbase   ", x$GISDBASE, "\n")
-    cat("location   ", x$LOCATION_NAME, "\n")
-    cat("mapset     ", x$MAPSET, "\n")
-    cat("rows       ", x$rows, "\n")
-    cat("columns    ", x$cols, "\n")
-    cat("north      ", x$n, "\n")
-    cat("south      ", x$s, "\n")
-    cat("west       ", x$w, "\n")
-    cat("east       ", x$e, "\n")
-    cat("nsres      ", x$nsres, "\n")
-    cat("ewres      ", x$ewres, "\n")
-    if (is.character(x$proj4[1]) && nzchar(x$proj4[1]))
-        if (substr(x$proj4[1], 1, 1) == "+") 
-            cat("projection ", paste(strwrap(x$proj4), collapse="\n"), "\n")
-        else cat("projection:\n", x$proj4[1], "\n")
-    invisible(x)
+  cat("gisdbase   ", x$GISDBASE, "\n")
+  cat("location   ", x$LOCATION_NAME, "\n")
+  cat("mapset     ", x$MAPSET, "\n")
+  cat("rows       ", x$rows, "\n")
+  cat("columns    ", x$cols, "\n")
+  cat("north      ", x$n, "\n")
+  cat("south      ", x$s, "\n")
+  cat("west       ", x$w, "\n")
+  cat("east       ", x$e, "\n")
+  cat("nsres      ", x$nsres, "\n")
+  cat("ewres      ", x$ewres, "\n")
+  if (is.character(x$proj4[1]) && nzchar(x$proj4[1]))
+    if (substr(x$proj4[1], 1, 1) == "+")
+      cat("projection ", paste(strwrap(x$proj4), collapse = "\n"), "\n")
+    else cat("projection:\n", x$proj4[1], "\n")
+  invisible(x)
 }
 
 gmeta2grd <- function(ignore.stderr = FALSE) {
-	if (!requireNamespace("sp", quietly=TRUE))
-		stop("sp required to creat a GridTopology object")
-	G <- gmeta(ignore.stderr=ignore.stderr)
-	cellcentre.offset <- c(G$w+(G$ewres/2), G$s+(G$nsres/2))
-	cellsize <- c(G$ewres, G$nsres)
-	cells.dim <- c(G$cols, G$rows)
+  if (!requireNamespace("sp", quietly = TRUE))
+    stop("sp required to creat a GridTopology object")
+  G <- gmeta(ignore.stderr = ignore.stderr)
+  cellcentre.offset <- c(G$w + (G$ewres / 2), G$s + (G$nsres / 2))
+  cellsize <- c(G$ewres, G$nsres)
+  cells.dim <- c(G$cols, G$rows)
 
-	grd <- sp::GridTopology(cellcentre.offset=cellcentre.offset, 
-		cellsize=cellsize, cells.dim=cells.dim)
-	grd
+  grd <- sp::GridTopology(
+    cellcentre.offset = cellcentre.offset,
+    cellsize = cellsize, cells.dim = cells.dim
+  )
+  grd
 }
 
 
 
-getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT=NULL) {
-# too strict assumption on g.proj Rohan Sadler 20050928
-    if (get.suppressEchoCmdInFuncOption()) {
-        inEchoCmd <- get.echoCmdOption()
-         tull <- set.echoCmdOption(FALSE)
+getLocationProj <- function(ignore.stderr = FALSE, g.proj_WKT = NULL) {
+  # too strict assumption on g.proj Rohan Sadler 20050928
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- get.echoCmdOption()
+    tull <- set.echoCmdOption(FALSE)
+  }
+  gv <- .grassVersion()
+  WKT2 <- gv >= "GRASS 7.6"
+  old_proj <- TRUE
+  if (requireNamespace("terra", quietly = TRUE))
+    old_proj <- as.integer(substring(terra::gdal(lib = "proj"), 1, 1)) <= 5L
+  if (!is.null(g.proj_WKT)) {
+    stopifnot(is.logical(g.proj_WKT))
+    stopifnot(length(g.proj_WKT) == 1L)
+    if (gv < "GRASS 7.6" || g.proj_WKT)
+      warning("Only Proj4 string representation for GRASS < 7.6")
+    if (!g.proj_WKT) WKT2 <- FALSE
+  }
+  if (WKT2 && !old_proj) {
+    res <- paste(execGRASS("g.proj",
+      flags = c("w"), intern = TRUE,
+      ignore.stderr = ignore.stderr
+    ), collapse = "\n")
+    if (substr(res, 1, 5) != "ERROR") {
+      if (nchar(res) == 0L) {
+        res <- paste(execGRASS("g.proj",
+          flags = c("j"), intern = TRUE,
+          ignore.stderr = ignore.stderr
+        ), collapse = " ")
+      }
+      return(res)
     }
-    gv <- .grassVersion()
-    WKT2 <- gv >= "GRASS 7.6" 
-    old_proj <- TRUE
-    if (requireNamespace("terra", quietly = TRUE)) 
-        old_proj <- as.integer(substring(terra::gdal(lib="proj"), 1, 1)) <= 5L
-    if (!is.null(g.proj_WKT)) {
-        stopifnot(is.logical(g.proj_WKT))
-        stopifnot(length(g.proj_WKT) == 1L)
-        if (gv < "GRASS 7.6" || g.proj_WKT)
-            warning("Only Proj4 string representation for GRASS < 7.6")
-        if (!g.proj_WKT) WKT2 <- FALSE
-    }
-    if (WKT2 && !old_proj) {
-        res <- paste(execGRASS("g.proj", flags=c("w"), intern=TRUE, 
-            ignore.stderr=ignore.stderr), collapse="\n")
-        if (substr(res, 1, 5) != "ERROR") {
-            if (nchar(res) == 0L) {
-                res <- paste(execGRASS("g.proj", flags=c("j"), intern=TRUE, 
-                    ignore.stderr=ignore.stderr), collapse=" ")
-            }
-            return(res)
-        }
-    }
-    projstr <- execGRASS("g.proj", flags=c("j", "f"), intern=TRUE, 
-        ignore.stderr=ignore.stderr)
-    if (length(grep("XY location", projstr)) > 0)
-	projstr <- as.character(NA)
-    if (length(grep("latlong", projstr)) > 0)
-	projstr <- sub("latlong", "longlat", projstr)
-    if (is.na(projstr)) uprojargs <- projstr
-    	else uprojargs <- paste(unique(unlist(strsplit(projstr, " "))), 
-		collapse=" ")
-    if (length(grep("= ", uprojargs)) != 0) {
-	warning(paste("No spaces permitted in PROJ4",
-		"argument-value pairs:", uprojargs))
-	uprojargs <- as.character(NA)
-    }
-    if (length(grep(" [:alnum:]", uprojargs)) != 0) {
-	warning(paste("PROJ4 argument-value pairs",
-		"must begin with +:", uprojargs))
-	uprojargs <- as.character(NA)
-    }
-    if (get.suppressEchoCmdInFuncOption()) {
-        tull <- set.echoCmdOption(inEchoCmd)
-    }
-    uprojargs
+  }
+  projstr <- execGRASS("g.proj",
+    flags = c("j", "f"), intern = TRUE,
+    ignore.stderr = ignore.stderr
+  )
+  if (length(grep("XY location", projstr)) > 0)
+    projstr <- as.character(NA)
+  if (length(grep("latlong", projstr)) > 0)
+    projstr <- sub("latlong", "longlat", projstr)
+  if (is.na(projstr)) uprojargs <- projstr
+  else uprojargs <- paste(unique(unlist(strsplit(projstr, " "))),
+    collapse = " "
+  )
+  if (length(grep("= ", uprojargs)) != 0) {
+    warning(paste(
+      "No spaces permitted in PROJ4",
+      "argument-value pairs:", uprojargs
+    ))
+    uprojargs <- as.character(NA)
+  }
+  if (length(grep(" [:alnum:]", uprojargs)) != 0) {
+    warning(paste(
+      "PROJ4 argument-value pairs",
+      "must begin with +:", uprojargs
+    ))
+    uprojargs <- as.character(NA)
+  }
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  uprojargs
 }
 
 .g_findfile <- function(vname, type) {
-    ms <- execGRASS("g.findfile", element=type, file=vname[1],
-        intern=TRUE)
-    tx <- gsub("=", ":", ms)
-    con <- textConnection(tx)
-    res <- read.dcf(con)
-    close(con)
-    lres <- as.list(res)
-    names(lres) <- colnames(res)
-    if (nchar(lres$name) == 0) 
-        stop(paste(vname[1], "- file not found"))
-    mapset <- gsub("'", "", lres$mapset)
-    mapset    
+  ms <- execGRASS("g.findfile",
+    element = type, file = vname[1],
+    intern = TRUE
+  )
+  tx <- gsub("=", ":", ms)
+  con <- textConnection(tx)
+  res <- read.dcf(con)
+  close(con)
+  lres <- as.list(res)
+  names(lres) <- colnames(res)
+  if (nchar(lres$name) == 0)
+    stop(paste(vname[1], "- file not found"))
+  mapset <- gsub("'", "", lres$mapset)
+  mapset
 }
 
 
 
 .addexe <- function() {
-    res <- ""
-    SYS <- get("SYS", envir=.GRASS_CACHE)
-    if (SYS == "WinNat") res =".exe"
-    res
+  res <- ""
+  SYS <- get("SYS", envir = .GRASS_CACHE)
+  if (SYS == "WinNat") res = ".exe"
+  res
 }
 
 
-.grassVersion <- function(ignore.stderr=TRUE) {
-    Gver <- try(execGRASS(
-        "g.version",
-        intern = TRUE, 
-        ignore.stderr = ignore.stderr), silent=TRUE)
-    if (inherits(Gver, "try-error"))
-        Gver <- "sh: line 1: g.version: command not found"
-    return(Gver)
+.grassVersion <- function(ignore.stderr = TRUE) {
+  Gver <- try(execGRASS(
+    "g.version",
+    intern = TRUE,
+    ignore.stderr = ignore.stderr
+  ), silent = TRUE)
+  if (inherits(Gver, "try-error"))
+    Gver <- "sh: line 1: g.version: command not found"
+  return(Gver)
 }
 
-.compatibleGRASSVersion <- function(gv=.grassVersion()) {
-    compatible <- ( (gv >= "GRASS 7.0") & (gv < "GRASS 9.0") )
-    if (gv == "sh: line 1: g.version: command not found") {
-        compatible <- as.logical(NA)
-        attr(compatible, "message") <- gv
-        return(compatible)
-    }
-    if ( !compatible ){
-        attr(compatible, "message") <- paste0(
-            "\n### rgrass7 is not compatible with the GRASS GIS version '", gv, "'!",
-            "\n### Please use the package appropriate to the GRASS GIS version:",
-            "\n### GRASS GIS Version 5.x.y  --  GRASS",
-            "\n### GRASS GIS Version 6.x.y  --  spgrass6",
-            "\n### GRASS GIS Version 7.x.y  --  rgrass7",
-            "\n### GRASS GIS Version 8.x.y  --  rgrass"
-        )
-    } else {
-        attr(compatible, "message") <- paste0("rgrass7 is compatible with the GRASS GIS version '", gv, "' R is running in!")
-    }
+.compatibleGRASSVersion <- function(gv = .grassVersion()) {
+  compatible <- ((gv >= "GRASS 7.0") & (gv < "GRASS 9.0"))
+  if (gv == "sh: line 1: g.version: command not found") {
+    compatible <- as.logical(NA)
+    attr(compatible, "message") <- gv
     return(compatible)
+  }
+  if (!compatible) {
+    attr(compatible, "message") <- paste0(
+      "\n### rgrass7 is not compatible with the GRASS GIS version '", gv, "'!",
+      "\n### Please use the package appropriate to the GRASS GIS version:",
+      "\n### GRASS GIS Version 5.x.y  --  GRASS",
+      "\n### GRASS GIS Version 6.x.y  --  spgrass6",
+      "\n### GRASS GIS Version 7.x.y  --  rgrass7",
+      "\n### GRASS GIS Version 8.x.y  --  rgrass"
+    )
+  } else {
+    attr(compatible, "message") <- paste0("rgrass7 is compatible with the GRASS GIS version '", gv, "' R is running in!")
+  }
+  return(compatible)
 }
 
-.get_R_interface <- function() get("R_interface", envir=.GRASS_CACHE)
-
-
+.get_R_interface <- function() get("R_interface", envir = .GRASS_CACHE)

--- a/R/vect_link.R
+++ b/R/vect_link.R
@@ -4,85 +4,95 @@
 
 
 vInfo <- function(vname, layer, ignore.stderr = NULL) {
-        if (get.suppressEchoCmdInFuncOption()) {
-            inEchoCmd <- get.echoCmdOption()
-             tull <- set.echoCmdOption(FALSE)
-        }
-        if (is.null(ignore.stderr))
-            ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
-        stopifnot(is.logical(ignore.stderr))
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- get.echoCmdOption()
+    tull <- set.echoCmdOption(FALSE)
+  }
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  stopifnot(is.logical(ignore.stderr))
 
-        if (missing(layer)) layer <- "1"
-        layer <- as.character(layer)
-	vinfo0 <- execGRASS("v.info", flags="t", map=vname,
-            layer=layer, intern=TRUE, ignore.stderr=ignore.stderr)
+  if (missing(layer)) layer <- "1"
+  layer <- as.character(layer)
+  vinfo0 <- execGRASS("v.info",
+    flags = "t", map = vname,
+    layer = layer, intern = TRUE, ignore.stderr = ignore.stderr
+  )
 
-# fix to avoid locale problems 091022
+  # fix to avoid locale problems 091022
 
-        vinfo1 <- gsub("=", ":", vinfo0)
-	con <- textConnection(vinfo1)
-	res <- drop(read.dcf(con))
-	close(con)
-        if (get.suppressEchoCmdInFuncOption()) {
-            tull <- set.echoCmdOption(inEchoCmd)
-        }
-	storage.mode(res) <- "integer"
-	res
+  vinfo1 <- gsub("=", ":", vinfo0)
+  con <- textConnection(vinfo1)
+  res <- drop(read.dcf(con))
+  close(con)
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  storage.mode(res) <- "integer"
+  res
 }
 
 vColumns <- function(vname, layer, ignore.stderr = NULL) {
-        if (get.suppressEchoCmdInFuncOption()) {
-            inEchoCmd <- get.echoCmdOption()
-             tull <- set.echoCmdOption(FALSE)
-        }
-        if (is.null(ignore.stderr))
-            ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
-        stopifnot(is.logical(ignore.stderr))
-        if (missing(layer)) layer <- "1"
-        layer <- as.character(layer)
-	vinfo0 <- execGRASS("v.info", flags="c", map=vname,
-            layer=layer, intern=TRUE, ignore.stderr=ignore.stderr)       
-        vinfo1 <- strsplit(vinfo0, "\\|")
-        vinfo2 <- vinfo1[sapply(vinfo1, length) == 2]
-        if (length(vinfo1) != length(vinfo2))
-            warning("vColumns: v.info -c output not in two columns:\n",
-                paste(vinfo1[sapply(vinfo1, length) != 2]))
-        res <- as.data.frame(do.call("rbind", vinfo2))
-	names(res) <- c("storageType", "name")
-        if (get.suppressEchoCmdInFuncOption()) {
-            tull <- set.echoCmdOption(inEchoCmd)
-        }
-	res
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- get.echoCmdOption()
+    tull <- set.echoCmdOption(FALSE)
+  }
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  stopifnot(is.logical(ignore.stderr))
+  if (missing(layer)) layer <- "1"
+  layer <- as.character(layer)
+  vinfo0 <- execGRASS("v.info",
+    flags = "c", map = vname,
+    layer = layer, intern = TRUE, ignore.stderr = ignore.stderr
+  )
+  vinfo1 <- strsplit(vinfo0, "\\|")
+  vinfo2 <- vinfo1[sapply(vinfo1, length) == 2]
+  if (length(vinfo1) != length(vinfo2))
+    warning(
+      "vColumns: v.info -c output not in two columns:\n",
+      paste(vinfo1[sapply(vinfo1, length) != 2])
+    )
+  res <- as.data.frame(do.call("rbind", vinfo2))
+  names(res) <- c("storageType", "name")
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  res
 }
 
 vDataCount <- function(vname, layer, ignore.stderr = NULL) {
-        if (get.suppressEchoCmdInFuncOption()) {
-            inEchoCmd <- get.echoCmdOption()
-             tull <- set.echoCmdOption(FALSE)
-        }
-        if (is.null(ignore.stderr))
-            ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
-        stopifnot(is.logical(ignore.stderr))
-        column <- "column" %in% parseGRASS("v.db.select")$pnames
-        if (missing(layer)) layer <- "1"
-        layer <- as.character(layer)
-        parms <- list(map=vname, layer=as.character(layer), columns="cat")
-        if (column) tull <- execGRASS("v.db.select", flags="c",
-            parameters=parms, intern=TRUE, ignore.stderr=ignore.stderr)
-        else tull <- execGRASS("v.db.select", flags="c",
-            parameters=parms, intern=TRUE, ignore.stderr=ignore.stderr)
-	n <- length(tull)
-        if (get.suppressEchoCmdInFuncOption()) {
-            tull <- set.echoCmdOption(inEchoCmd)
-        }
-	n
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- get.echoCmdOption()
+    tull <- set.echoCmdOption(FALSE)
+  }
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  stopifnot(is.logical(ignore.stderr))
+  column <- "column" %in% parseGRASS("v.db.select")$pnames
+  if (missing(layer)) layer <- "1"
+  layer <- as.character(layer)
+  parms <- list(map = vname, layer = as.character(layer), columns = "cat")
+  if (column) tull <- execGRASS("v.db.select",
+    flags = "c",
+    parameters = parms, intern = TRUE, ignore.stderr = ignore.stderr
+  )
+  else tull <- execGRASS("v.db.select",
+    flags = "c",
+    parameters = parms, intern = TRUE, ignore.stderr = ignore.stderr
+  )
+  n <- length(tull)
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  n
 }
 
 
-#Date: Thu, 13 Oct 2005 17:34:06 +0200
-#From: Markus Neteler <neteler@itc.it>
+# Date: Thu, 13 Oct 2005 17:34:06 +0200
+# From: Markus Neteler <neteler@itc.it>
 #
-#EXERCISE: HOW LONG ARE COMMON BOUNDARIES OF POLYGONS?
+# EXERCISE: HOW LONG ARE COMMON BOUNDARIES OF POLYGONS?
 #
 #
 ## Requires: GRASS 6.1-CVS from 13 Oct 2005 or later
@@ -90,42 +100,42 @@ vDataCount <- function(vname, layer, ignore.stderr = NULL) {
 ## data: sudden infant deaths data from North Carolina
 ## data imported from SHAPE file with v.in.ogr
 #
-##let's have a look
+## let's have a look
 # d.mon x0
 # d.vect sids
 #
-##we work on a copy:
+## we work on a copy:
 # g.copy vect=sids,sids_nc
 #
-##we add a second layer to the map which references the boundaries of
-##polygons. In the vector geometry we generate an ID (category) for each
-##boundary:
+## we add a second layer to the map which references the boundaries of
+## polygons. In the vector geometry we generate an ID (category) for each
+## boundary:
 # v.category sids_nc out=sids_nc2 layer=2 type=boundary option=add
 #
-##Underlying idea:
-##we'll fetch the IDs (categories) of the polygons left and right from
-##each boundary and store it into the attribute table linked to layer 2.
-##In general:
+## Underlying idea:
+## we'll fetch the IDs (categories) of the polygons left and right from
+## each boundary and store it into the attribute table linked to layer 2.
+## In general:
 ## cat_of_boundary | cat_of_left_polygon | cat_of_right_polygon | length_of_boundary
 ##
-##We want only one category per boundary, that's why the sides check is
-##needed (a boundary may consist of several pieces)
+## We want only one category per boundary, that's why the sides check is
+## needed (a boundary may consist of several pieces)
 ##
-##So we create a new attribute table and link it to the new layer 2
-##of the vector map:
+## So we create a new attribute table and link it to the new layer 2
+## of the vector map:
 # v.db.addtable sids_nc2 layer=2 col="left integer,right integer,length integer"
 #
-##Now we query the polygon/boundary relationsships and store it into
-##the attribute table linked to layer 2:
-# v.to.db map=sids_nc2 option=sides col=left,right layer=2 
+## Now we query the polygon/boundary relationsships and store it into
+## the attribute table linked to layer 2:
+# v.to.db map=sids_nc2 option=sides col=left,right layer=2
 #
-##Now we have unique categories for the boundaries and can calculate the
-##lengths:
-# v.to.db map=sids_nc2 option=length col=length layer=2 
+## Now we have unique categories for the boundaries and can calculate the
+## lengths:
+# v.to.db map=sids_nc2 option=length col=length layer=2
 #
-##Done.
+## Done.
 #
-##See the new attribute table containing the boundary lengths:
+## See the new attribute table containing the boundary lengths:
 # v.db.select sids_nc2 layer=2
 #
 ## verification (let's check boundary #193):
@@ -134,193 +144,211 @@ vDataCount <- function(vname, layer, ignore.stderr = NULL) {
 # d.measure
 ## LEN:     12756.00 meters
 #
-##what does the attribute table say:
+## what does the attribute table say:
 # v.db.select sids_nc2 layer=2 | grep '^193'
-##190|65|68|12814
+## 190|65|68|12814
 #
-##This is reasonably close since on screen digitization in d.measure
-##isn't always that precise ...
+## This is reasonably close since on screen digitization in d.measure
+## isn't always that precise ...
 #
 
-vect2neigh <- function(vname, ID=NULL, ignore.stderr = NULL, remove=TRUE,
-    vname2=NULL, units="k") {
+vect2neigh <- function(
+    vname, ID = NULL, ignore.stderr = NULL, remove = TRUE,
+    vname2 = NULL, units = "k") {
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- get.echoCmdOption()
+    tull <- set.echoCmdOption(FALSE)
+  }
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  stopifnot(is.logical(ignore.stderr))
 
-    if (get.suppressEchoCmdInFuncOption()) {
-        inEchoCmd <- get.echoCmdOption()
-        tull <- set.echoCmdOption(FALSE)
-    }
-    if (is.null(ignore.stderr))
-        ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
-    stopifnot(is.logical(ignore.stderr))
+  vinfo <- vInfo(vname)
+  types <- names(vinfo)[which(vinfo > 0)]
+  if (length(grep("areas", types)) == 0)
+    stop("Vector object not of area type")
 
-    vinfo <- vInfo(vname)
-    types <- names(vinfo)[which(vinfo > 0)]
-    if (length(grep("areas", types)) == 0) 
-		stop("Vector object not of area type")
-
-    n <- vDataCount(vname, ignore.stderr=ignore.stderr)
-
-
-    if (!is.null(ID)) {
-		if (!is.character(ID)) stop("ID not character string")
-#		cmd <- paste(paste("v.info", .addexe(), sep=""),
-#                    " -c ", vname, sep="")
-#		if(.Platform$OS.type == "windows") 
-#			tull <- system(cmd, intern=TRUE)
-#		else tull <- system(cmd, intern=TRUE, 
-#			ignore.stderr=ignore.stderr)
-                tull <- execGRASS("v.info", flags="c",
-                        map=vname, intern=TRUE, 
-			ignore.stderr=ignore.stderr)
-		if (length(grep(ID, tull)) == 0)
-			stop("ID not found")
-#		cmd <- paste(paste("v.db.select", .addexe(), sep=""),
-#                    " -c map=", vname, " column=", 
-#			ID, sep="")
-#		if(.Platform$OS.type == "windows") 
-#			ID <- as.character(system(cmd, intern=TRUE))
-#		else ID <- as.character(system(cmd, intern=TRUE, 
-#			ignore.stderr=ignore.stderr))
-                ID <- execGRASS("v.db.select", flags="c", 
-                        map=vname, columns=ID, intern=TRUE, 
-			ignore.stderr=ignore.stderr) 
-		if (length(unique(ID)) != n) 
-			stop("fewer than n unique ID values")
-    }
-    vname2_was_null <- FALSE
-    if (is.null(vname2)) {
-	
-	pid <- as.integer(round(runif(1, 1, 1000)))
-	vname2 <- paste(vname, pid, sep="")
-        tull <- execGRASS("g.remove", type="vector", name=vname2, flags="f",
-            intern=TRUE, ignore.stderr=ignore.stderr)
-#	cmd <- paste(paste("g.copy", .addexe(), sep=""),
-#                    " vect=", vname, ",", vname2, sep="")
-#	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
-#	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
-        tull <- execGRASS("g.copy", vector=paste(vname, 
-            vname2, sep=","), flags="overwrite", intern=TRUE,
-            ignore.stderr=ignore.stderr)
-        vname2_was_null <- TRUE
-    }
-    vname2a <- paste(vname2, "a", sep="")
-    if (vname2_was_null) {
-#	cmd <- paste(paste("v.category", .addexe(), sep=""),
-#                    " ", vname2, " out=", vname2a, 
-#		"  layer=2 type=boundary option=add", sep="")
-#	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
-#	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
-        tull <- execGRASS("v.category", input=vname2,
-                output=vname2a, layer=as.character(2), type="boundary",
-                option="add", flags="overwrite", intern=TRUE, ignore.stderr=ignore.stderr)
-
-#	cmd <- paste(paste("v.db.addtable", .addexe(), sep=""),
-#                    " ", vname2a, 
-#	" layer=2 col=\"left integer,right integer,length double precision\"", 
-#	sep="")
-#	if(.Platform$OS.type == "windows") system(cmd)
-#	else system(cmd, ignore.stderr=ignore.stderr)
-        execGRASS("v.db.addtable", map=vname2a, 
-                layer=as.integer(2),
-                columns="left integer,right integer,length double precision",
-                ignore.stderr=ignore.stderr)
-
-# Using vector map name extended by layer number as table name: landuse175a_2
-#Creating table with columns (cat integer, left integer,right integer,length
-# double precision)
-# The table <landuse175a_2> is now part of vector map <landuse175a> and may
-# be deleted or overwritten by GRASS modules
-# Select privileges were granted on the table
-# Reading features...
-# 
-# and: no such driver available
-# WARNING: Unable to start driver <and>
-# ERROR: Unable to open database <C:\Documents> by driver <and>
-# Current attribute table links:
-# layer <1> table <landuse175a> in database <C:\Documents and Settings\s1155\My Documents\GIS DataBase/Spearfish60/s1155/dbf/> through driver <dbf> with key <cat>
-# layer <2> table <landuse175a_2> in database <C:\Documents> through driver <and> with key <cat>
-# Vector map <landuse175a@s1155> is connected by:
+  n <- vDataCount(vname, ignore.stderr = ignore.stderr)
 
 
-#	cmd <- paste(paste("v.to.db", .addexe(), sep=""),
-#                    " map=", vname2a, 
-#		" option=sides col=left,right layer=2", sep="")
-#	if(.Platform$OS.type == "windows") system(cmd)
-#	else system(cmd, ignore.stderr=ignore.stderr)
-        execGRASS("v.to.db", flags=c("overwrite"), map=vname2a, option="sides",
-                columns="left,right", layer=as.character(2),
-                ignore.stderr=ignore.stderr)
+  if (!is.null(ID)) {
+    if (!is.character(ID)) stop("ID not character string")
+    # 		cmd <- paste(paste("v.info", .addexe(), sep=""),
+    #                    " -c ", vname, sep="")
+    # 		if(.Platform$OS.type == "windows")
+    # 			tull <- system(cmd, intern=TRUE)
+    # 		else tull <- system(cmd, intern=TRUE,
+    # 			ignore.stderr=ignore.stderr)
+    tull <- execGRASS("v.info",
+      flags = "c",
+      map = vname, intern = TRUE,
+      ignore.stderr = ignore.stderr
+    )
+    if (length(grep(ID, tull)) == 0)
+      stop("ID not found")
+    # 		cmd <- paste(paste("v.db.select", .addexe(), sep=""),
+    #                    " -c map=", vname, " column=",
+    # 			ID, sep="")
+    # 		if(.Platform$OS.type == "windows")
+    # 			ID <- as.character(system(cmd, intern=TRUE))
+    # 		else ID <- as.character(system(cmd, intern=TRUE,
+    # 			ignore.stderr=ignore.stderr))
+    ID <- execGRASS("v.db.select",
+      flags = "c",
+      map = vname, columns = ID, intern = TRUE,
+      ignore.stderr = ignore.stderr
+    )
+    if (length(unique(ID)) != n)
+      stop("fewer than n unique ID values")
+  }
+  vname2_was_null <- FALSE
+  if (is.null(vname2)) {
+    pid <- as.integer(round(runif(1, 1, 1000)))
+    vname2 <- paste(vname, pid, sep = "")
+    tull <- execGRASS("g.remove",
+      type = "vector", name = vname2, flags = "f",
+      intern = TRUE, ignore.stderr = ignore.stderr
+    )
+    # 	cmd <- paste(paste("g.copy", .addexe(), sep=""),
+    #                    " vect=", vname, ",", vname2, sep="")
+    # 	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
+    # 	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
+    tull <- execGRASS("g.copy",
+      vector = paste(vname,
+        vname2,
+        sep = ","
+      ), flags = "overwrite", intern = TRUE,
+      ignore.stderr = ignore.stderr
+    )
+    vname2_was_null <- TRUE
+  }
+  vname2a <- paste(vname2, "a", sep = "")
+  if (vname2_was_null) {
+    # 	cmd <- paste(paste("v.category", .addexe(), sep=""),
+    #                    " ", vname2, " out=", vname2a,
+    # 		"  layer=2 type=boundary option=add", sep="")
+    # 	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
+    # 	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
+    tull <- execGRASS("v.category",
+      input = vname2,
+      output = vname2a, layer = as.character(2), type = "boundary",
+      option = "add", flags = "overwrite", intern = TRUE, ignore.stderr = ignore.stderr
+    )
 
-#	cmd <- paste(paste("v.to.db", .addexe(), sep=""),
-#                    " map=", vname2a, 
-#		" option=length col=length layer=2", sep="")
-#	if(.Platform$OS.type == "windows") system(cmd)
-#	else system(cmd, ignore.stderr=ignore.stderr)
-        execGRASS("v.to.db", flags=c("overwrite"), map=vname2a, option="length",
-                columns="length", layer=as.character(2), units=units,
-                ignore.stderr=ignore.stderr)
+    # 	cmd <- paste(paste("v.db.addtable", .addexe(), sep=""),
+    #                    " ", vname2a,
+    # 	" layer=2 col=\"left integer,right integer,length double precision\"",
+    # 	sep="")
+    # 	if(.Platform$OS.type == "windows") system(cmd)
+    # 	else system(cmd, ignore.stderr=ignore.stderr)
+    execGRASS("v.db.addtable",
+      map = vname2a,
+      layer = as.integer(2),
+      columns = "left integer,right integer,length double precision",
+      ignore.stderr = ignore.stderr
+    )
 
-#	cmd <- paste(paste("v.db.select", .addexe(), sep=""),
-#                    " ", vname2a, " layer=2", sep="")
-#
-#	if(.Platform$OS.type == "windows") res <- system(cmd, intern=TRUE)
-#	else res <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
-    }
-    res <- execGRASS("v.db.select", map=vname2a,
-          layer=as.character(2), flags="overwrite", intern=TRUE,
-          ignore.stderr=ignore.stderr)
+    # Using vector map name extended by layer number as table name: landuse175a_2
+    # Creating table with columns (cat integer, left integer,right integer,length
+    # double precision)
+    # The table <landuse175a_2> is now part of vector map <landuse175a> and may
+    # be deleted or overwritten by GRASS modules
+    # Select privileges were granted on the table
+    # Reading features...
+    #
+    # and: no such driver available
+    # WARNING: Unable to start driver <and>
+    # ERROR: Unable to open database <C:\Documents> by driver <and>
+    # Current attribute table links:
+    # layer <1> table <landuse175a> in database <C:\Documents and Settings\s1155\My Documents\GIS DataBase/Spearfish60/s1155/dbf/> through driver <dbf> with key <cat>
+    # layer <2> table <landuse175a_2> in database <C:\Documents> through driver <and> with key <cat>
+    # Vector map <landuse175a@s1155> is connected by:
 
-#	cmd <- paste(paste("g.remove", .addexe(), sep=""),
-#                    " vect=", vname2, ",", vname2a, sep="")
-#	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
-#	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
-    if (remove) tull <- execGRASS("g.remove",
-            name=paste(vname2, vname2a, sep=","), type="vector",
-            intern=TRUE, ignore.stderr=ignore.stderr)
 
-    con <- textConnection(res)
-    t2 <- read.table(con, sep="|", header=TRUE, row.names=1)
-    close(con)
-    t3 <- t2[t2$left == -1,]
-    t4 <- tapply(t3$length, t3$right, sum)
-    external <- numeric(n)
-    external[as.integer(names(t4))] <- t4
-    t5 <- t2[!t2$left == -1,]
-    tmp <- t5$left
-    t5$left <- t5$right
-    t5$right <- tmp
-    t6 <- rbind(t2, t5)
-    total <- c(tapply(t6$length, t6$right, sum))
-    res <- t6[!t6$left == -1,]
-#       avoid integer overflow in by=
-#	res <- aggregate(res[3], by=list(left=res$left, right=res$right), sum)
-#        dups <- duplicated(res[,1:2])
-#        resd <- res[dups,]
-#        resda <- aggregate(resd[3], by=list(left=resd$left,
-#            right=resd$right), sum)
-#        resnd <- res[!dups,]
-#        res <- rbind(resda, resnd)
-    zz <- paste(res$left, res$right, sep=":")
-    uzz <- unique(zz)
-    mo <- match(zz, uzz)
-    smo <- c(tapply(res[,3], mo, sum))
-    names(smo) <- NULL
-    suzz <- strsplit(uzz, ":")
-    lsuzz <- as.integer(sapply(suzz, "[", 1))
-    rsuzz <- as.integer(sapply(suzz, "[", 2))
-    reso <- data.frame(left=lsuzz, right=rsuzz, length=smo)
-    o <- order(reso$left, reso$right)
-    reso <- reso[o,]
-    attr(reso, "external") <- external
-    attr(reso, "total") <- total
-    attr(reso, "region.id") <- ID
-    attr(reso, "n") <- n
-    class(reso) <- c(class(reso), "GRASSneigh", "spatial.neighbour")
-    if (get.suppressEchoCmdInFuncOption()) {
-        tull <- set.echoCmdOption(inEchoCmd)
-    }
+    # 	cmd <- paste(paste("v.to.db", .addexe(), sep=""),
+    #                    " map=", vname2a,
+    # 		" option=sides col=left,right layer=2", sep="")
+    # 	if(.Platform$OS.type == "windows") system(cmd)
+    # 	else system(cmd, ignore.stderr=ignore.stderr)
+    execGRASS("v.to.db",
+      flags = c("overwrite"), map = vname2a, option = "sides",
+      columns = "left,right", layer = as.character(2),
+      ignore.stderr = ignore.stderr
+    )
 
-    reso
+    # 	cmd <- paste(paste("v.to.db", .addexe(), sep=""),
+    #                    " map=", vname2a,
+    # 		" option=length col=length layer=2", sep="")
+    # 	if(.Platform$OS.type == "windows") system(cmd)
+    # 	else system(cmd, ignore.stderr=ignore.stderr)
+    execGRASS("v.to.db",
+      flags = c("overwrite"), map = vname2a, option = "length",
+      columns = "length", layer = as.character(2), units = units,
+      ignore.stderr = ignore.stderr
+    )
+
+    # 	cmd <- paste(paste("v.db.select", .addexe(), sep=""),
+    #                    " ", vname2a, " layer=2", sep="")
+    #
+    # 	if(.Platform$OS.type == "windows") res <- system(cmd, intern=TRUE)
+    # 	else res <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
+  }
+  res <- execGRASS("v.db.select",
+    map = vname2a,
+    layer = as.character(2), flags = "overwrite", intern = TRUE,
+    ignore.stderr = ignore.stderr
+  )
+
+  # 	cmd <- paste(paste("g.remove", .addexe(), sep=""),
+  #                    " vect=", vname2, ",", vname2a, sep="")
+  # 	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
+  # 	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
+  if (remove) tull <- execGRASS("g.remove",
+    name = paste(vname2, vname2a, sep = ","), type = "vector",
+    intern = TRUE, ignore.stderr = ignore.stderr
+  )
+
+  con <- textConnection(res)
+  t2 <- read.table(con, sep = "|", header = TRUE, row.names = 1)
+  close(con)
+  t3 <- t2[t2$left == -1, ]
+  t4 <- tapply(t3$length, t3$right, sum)
+  external <- numeric(n)
+  external[as.integer(names(t4))] <- t4
+  t5 <- t2[!t2$left == -1, ]
+  tmp <- t5$left
+  t5$left <- t5$right
+  t5$right <- tmp
+  t6 <- rbind(t2, t5)
+  total <- c(tapply(t6$length, t6$right, sum))
+  res <- t6[!t6$left == -1, ]
+  #       avoid integer overflow in by=
+  # 	res <- aggregate(res[3], by=list(left=res$left, right=res$right), sum)
+  #        dups <- duplicated(res[,1:2])
+  #        resd <- res[dups,]
+  #        resda <- aggregate(resd[3], by=list(left=resd$left,
+  #            right=resd$right), sum)
+  #        resnd <- res[!dups,]
+  #        res <- rbind(resda, resnd)
+  zz <- paste(res$left, res$right, sep = ":")
+  uzz <- unique(zz)
+  mo <- match(zz, uzz)
+  smo <- c(tapply(res[, 3], mo, sum))
+  names(smo) <- NULL
+  suzz <- strsplit(uzz, ":")
+  lsuzz <- as.integer(sapply(suzz, "[", 1))
+  rsuzz <- as.integer(sapply(suzz, "[", 2))
+  reso <- data.frame(left = lsuzz, right = rsuzz, length = smo)
+  o <- order(reso$left, reso$right)
+  reso <- reso[o, ]
+  attr(reso, "external") <- external
+  attr(reso, "total") <- total
+  attr(reso, "region.id") <- ID
+  attr(reso, "n") <- n
+  class(reso) <- c(class(reso), "GRASSneigh", "spatial.neighbour")
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+
+  reso
 }
-
-

--- a/R/vect_link.R
+++ b/R/vect_link.R
@@ -8,8 +8,9 @@ vInfo <- function(vname, layer, ignore.stderr = NULL) {
     inEchoCmd <- get.echoCmdOption()
     tull <- set.echoCmdOption(FALSE)
   }
-  if (is.null(ignore.stderr))
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  }
   stopifnot(is.logical(ignore.stderr))
 
   if (missing(layer)) layer <- "1"
@@ -37,8 +38,9 @@ vColumns <- function(vname, layer, ignore.stderr = NULL) {
     inEchoCmd <- get.echoCmdOption()
     tull <- set.echoCmdOption(FALSE)
   }
-  if (is.null(ignore.stderr))
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  }
   stopifnot(is.logical(ignore.stderr))
   if (missing(layer)) layer <- "1"
   layer <- as.character(layer)
@@ -48,11 +50,12 @@ vColumns <- function(vname, layer, ignore.stderr = NULL) {
   )
   vinfo1 <- strsplit(vinfo0, "\\|")
   vinfo2 <- vinfo1[sapply(vinfo1, length) == 2]
-  if (length(vinfo1) != length(vinfo2))
+  if (length(vinfo1) != length(vinfo2)) {
     warning(
       "vColumns: v.info -c output not in two columns:\n",
       paste(vinfo1[sapply(vinfo1, length) != 2])
     )
+  }
   res <- as.data.frame(do.call("rbind", vinfo2))
   names(res) <- c("storageType", "name")
   if (get.suppressEchoCmdInFuncOption()) {
@@ -66,21 +69,25 @@ vDataCount <- function(vname, layer, ignore.stderr = NULL) {
     inEchoCmd <- get.echoCmdOption()
     tull <- set.echoCmdOption(FALSE)
   }
-  if (is.null(ignore.stderr))
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  }
   stopifnot(is.logical(ignore.stderr))
   column <- "column" %in% parseGRASS("v.db.select")$pnames
   if (missing(layer)) layer <- "1"
   layer <- as.character(layer)
   parms <- list(map = vname, layer = as.character(layer), columns = "cat")
-  if (column) tull <- execGRASS("v.db.select",
-    flags = "c",
-    parameters = parms, intern = TRUE, ignore.stderr = ignore.stderr
-  )
-  else tull <- execGRASS("v.db.select",
-    flags = "c",
-    parameters = parms, intern = TRUE, ignore.stderr = ignore.stderr
-  )
+  if (column) {
+    tull <- execGRASS("v.db.select",
+      flags = "c",
+      parameters = parms, intern = TRUE, ignore.stderr = ignore.stderr
+    )
+  } else {
+    tull <- execGRASS("v.db.select",
+      flags = "c",
+      parameters = parms, intern = TRUE, ignore.stderr = ignore.stderr
+    )
+  }
   n <- length(tull)
   if (get.suppressEchoCmdInFuncOption()) {
     tull <- set.echoCmdOption(inEchoCmd)
@@ -159,14 +166,16 @@ vect2neigh <- function(
     inEchoCmd <- get.echoCmdOption()
     tull <- set.echoCmdOption(FALSE)
   }
-  if (is.null(ignore.stderr))
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get("ignore.stderr", envir = .GRASS_CACHE)
+  }
   stopifnot(is.logical(ignore.stderr))
 
   vinfo <- vInfo(vname)
   types <- names(vinfo)[which(vinfo > 0)]
-  if (length(grep("areas", types)) == 0)
+  if (length(grep("areas", types)) == 0) {
     stop("Vector object not of area type")
+  }
 
   n <- vDataCount(vname, ignore.stderr = ignore.stderr)
 
@@ -184,8 +193,9 @@ vect2neigh <- function(
       map = vname, intern = TRUE,
       ignore.stderr = ignore.stderr
     )
-    if (length(grep(ID, tull)) == 0)
+    if (length(grep(ID, tull)) == 0) {
       stop("ID not found")
+    }
     # 		cmd <- paste(paste("v.db.select", .addexe(), sep=""),
     #                    " -c map=", vname, " column=",
     # 			ID, sep="")
@@ -198,8 +208,9 @@ vect2neigh <- function(
       map = vname, columns = ID, intern = TRUE,
       ignore.stderr = ignore.stderr
     )
-    if (length(unique(ID)) != n)
+    if (length(unique(ID)) != n) {
       stop("fewer than n unique ID values")
+    }
   }
   vname2_was_null <- FALSE
   if (is.null(vname2)) {
@@ -303,10 +314,12 @@ vect2neigh <- function(
   #                    " vect=", vname2, ",", vname2a, sep="")
   # 	if(.Platform$OS.type == "windows") tull <- system(cmd, intern=TRUE)
   # 	else tull <- system(cmd, intern=TRUE, ignore.stderr=ignore.stderr)
-  if (remove) tull <- execGRASS("g.remove",
-    name = paste(vname2, vname2a, sep = ","), type = "vector",
-    intern = TRUE, ignore.stderr = ignore.stderr
-  )
+  if (remove) {
+    tull <- execGRASS("g.remove",
+      name = paste(vname2, vname2a, sep = ","), type = "vector",
+      intern = TRUE, ignore.stderr = ignore.stderr
+    )
+  }
 
   con <- textConnection(res)
   t2 <- read.table(con, sep = "|", header = TRUE, row.names = 1)

--- a/R/vect_link_ng.R
+++ b/R/vect_link_ng.R
@@ -1,63 +1,65 @@
 # Interpreted GRASS interface functions
 # Copyright (c) 2022 Roger S. Bivand
 #
-read_VECT <- function(vname, layer, type=NULL, flags="overwrite",
+read_VECT <- function(
+    vname, layer, type = NULL, flags = "overwrite",
     ignore.stderr = NULL) {
-    if (!(requireNamespace("terra", quietly=TRUE))) 
-        stop("terra required for SpatVector output")
-    if (is.null(ignore.stderr))
-        ignore.stderr <- get.ignore.stderrOption()
-    stopifnot(is.logical(ignore.stderr))
-    if (missing(layer)) layer <- "1"
-    layer <- as.character(layer)
-    if (get.suppressEchoCmdInFuncOption()) {
-        inEchoCmd <- set.echoCmdOption(FALSE)
-    }
-    vinfo <- vInfo(vname)
-    types <- names(vinfo)[which(vinfo > 0)]
-    if (is.null(type)) {
-        if (length(grep("points", types)) > 0) type <- "point"
-        if (length(grep("lines", types)) > 0) type <- "line"
-        if (length(grep("areas", types)) > 0) type <- "area"
-        if (is.null(type)) stop("Vector type not found")
-    }
-    tf <- tempfile(fileext=".gpkg")
-    execGRASS("v.out.ogr", flags=flags, input=vname, type=type,
-        layer=as.character(layer), output=tf, output_layer=vname,
-        format="GPKG", ignore.stderr=ignore.stderr)
-    res <- getMethod("vect", "character")(tf)
-    if (!all(getMethod("is.valid", "SpatVector")(res))) 
-        res <- getMethod("makeValid", "SpatVector")(res)
-    if (get.suppressEchoCmdInFuncOption()) {
-        tull <- set.echoCmdOption(inEchoCmd)
-    }
-    res
+  if (!(requireNamespace("terra", quietly = TRUE)))
+    stop("terra required for SpatVector output")
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get.ignore.stderrOption()
+  stopifnot(is.logical(ignore.stderr))
+  if (missing(layer)) layer <- "1"
+  layer <- as.character(layer)
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- set.echoCmdOption(FALSE)
+  }
+  vinfo <- vInfo(vname)
+  types <- names(vinfo)[which(vinfo > 0)]
+  if (is.null(type)) {
+    if (length(grep("points", types)) > 0) type <- "point"
+    if (length(grep("lines", types)) > 0) type <- "line"
+    if (length(grep("areas", types)) > 0) type <- "area"
+    if (is.null(type)) stop("Vector type not found")
+  }
+  tf <- tempfile(fileext = ".gpkg")
+  execGRASS("v.out.ogr",
+    flags = flags, input = vname, type = type,
+    layer = as.character(layer), output = tf, output_layer = vname,
+    format = "GPKG", ignore.stderr = ignore.stderr
+  )
+  res <- getMethod("vect", "character")(tf)
+  if (!all(getMethod("is.valid", "SpatVector")(res)))
+    res <- getMethod("makeValid", "SpatVector")(res)
+  if (get.suppressEchoCmdInFuncOption()) {
+    tull <- set.echoCmdOption(inEchoCmd)
+  }
+  res
 }
 
-write_VECT <- function(x, vname, flags="overwrite", ignore.stderr = NULL) {
+write_VECT <- function(x, vname, flags = "overwrite", ignore.stderr = NULL) {
+  if (!(requireNamespace("terra", quietly = TRUE)))
+    stop("terra required for SpatVector input")
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get.ignore.stderrOption()
+  stopifnot(is.logical(ignore.stderr))
+  if (get.suppressEchoCmdInFuncOption()) {
+    inEchoCmd <- set.echoCmdOption(FALSE)
+  }
+  type <- NULL
+  if (getMethod("geomtype", "SpatVector")(x) == "points") type <- "point"
+  if (getMethod("geomtype", "SpatVector")(x) == "lines") type <- "line"
+  if (getMethod("geomtype", "SpatVector")(x) == "polygons") type <- "boundary"
+  if (is.null(type)) stop("Unknown data class")
 
-    if (!(requireNamespace("terra", quietly=TRUE))) 
-        stop("terra required for SpatVector input")
-    if (is.null(ignore.stderr))
-            ignore.stderr <- get.ignore.stderrOption()
-    stopifnot(is.logical(ignore.stderr))
-    if (get.suppressEchoCmdInFuncOption()) {
-        inEchoCmd <- set.echoCmdOption(FALSE)
-    }
-    type <- NULL
-    if (getMethod("geomtype", "SpatVector")(x) == "points") type <- "point"
-    if (getMethod("geomtype", "SpatVector")(x) == "lines") type <- "line"
-    if (getMethod("geomtype", "SpatVector")(x) == "polygons") type <- "boundary"
-    if (is.null(type)) stop("Unknown data class")
+  tf <- tempfile(fileext = ".gpkg")
+  getMethod("writeVector", c("SpatVector", "character"))(x, filename = tf,
+    filetype = "GPKG", overwrite = TRUE)
 
-    tf <- tempfile(fileext=".gpkg")
-    getMethod("writeVector", c("SpatVector", "character"))(x, filename=tf,
-        filetype="GPKG", overwrite=TRUE)
-                    
-    execGRASS("v.in.ogr", flags=flags, input=tf, output=vname, type=type,
-        ignore.stderr=ignore.stderr)
-    if (get.suppressEchoCmdInFuncOption()) 
-        tull <- set.echoCmdOption(inEchoCmd)
+  execGRASS("v.in.ogr",
+    flags = flags, input = tf, output = vname, type = type,
+    ignore.stderr = ignore.stderr
+  )
+  if (get.suppressEchoCmdInFuncOption())
+    tull <- set.echoCmdOption(inEchoCmd)
 }
-
-

--- a/R/vect_link_ng.R
+++ b/R/vect_link_ng.R
@@ -4,10 +4,12 @@
 read_VECT <- function(
     vname, layer, type = NULL, flags = "overwrite",
     ignore.stderr = NULL) {
-  if (!(requireNamespace("terra", quietly = TRUE)))
+  if (!(requireNamespace("terra", quietly = TRUE))) {
     stop("terra required for SpatVector output")
-  if (is.null(ignore.stderr))
+  }
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get.ignore.stderrOption()
+  }
   stopifnot(is.logical(ignore.stderr))
   if (missing(layer)) layer <- "1"
   layer <- as.character(layer)
@@ -29,8 +31,9 @@ read_VECT <- function(
     format = "GPKG", ignore.stderr = ignore.stderr
   )
   res <- getMethod("vect", "character")(tf)
-  if (!all(getMethod("is.valid", "SpatVector")(res)))
+  if (!all(getMethod("is.valid", "SpatVector")(res))) {
     res <- getMethod("makeValid", "SpatVector")(res)
+  }
   if (get.suppressEchoCmdInFuncOption()) {
     tull <- set.echoCmdOption(inEchoCmd)
   }
@@ -38,10 +41,12 @@ read_VECT <- function(
 }
 
 write_VECT <- function(x, vname, flags = "overwrite", ignore.stderr = NULL) {
-  if (!(requireNamespace("terra", quietly = TRUE)))
+  if (!(requireNamespace("terra", quietly = TRUE))) {
     stop("terra required for SpatVector input")
-  if (is.null(ignore.stderr))
+  }
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get.ignore.stderrOption()
+  }
   stopifnot(is.logical(ignore.stderr))
   if (get.suppressEchoCmdInFuncOption()) {
     inEchoCmd <- set.echoCmdOption(FALSE)
@@ -60,6 +65,7 @@ write_VECT <- function(x, vname, flags = "overwrite", ignore.stderr = NULL) {
     flags = flags, input = tf, output = vname, type = type,
     ignore.stderr = ignore.stderr
   )
-  if (get.suppressEchoCmdInFuncOption())
+  if (get.suppressEchoCmdInFuncOption()) {
     tull <- set.echoCmdOption(inEchoCmd)
+  }
 }

--- a/R/xml1.R
+++ b/R/xml1.R
@@ -1,493 +1,580 @@
-parseGRASS <- function(cmd, legacyExec=NULL) {
-    cmdCACHE <- get("cmdCACHE", envir=.GRASS_CACHE)
-    res <- cmdCACHE[[cmd]]
-    if (is.null(legacyExec))
-        legacyExec <- get.legacyExecOption()
-    stopifnot(is.logical(legacyExec))
-    if (get("SYS", envir=.GRASS_CACHE) != "unix" && !legacyExec) {
-        warning("legacyExec set TRUE on non-unix platform")
-        legacyExec <- TRUE
+parseGRASS <- function(cmd, legacyExec = NULL) {
+  cmdCACHE <- get("cmdCACHE", envir = .GRASS_CACHE)
+  res <- cmdCACHE[[cmd]]
+  if (is.null(legacyExec))
+    legacyExec <- get.legacyExecOption()
+  stopifnot(is.logical(legacyExec))
+  if (get("SYS", envir = .GRASS_CACHE) != "unix" && !legacyExec) {
+    warning("legacyExec set TRUE on non-unix platform")
+    legacyExec <- TRUE
+  }
+  if (is.null(res)) {
+    ext <- get("addEXE", envir = .GRASS_CACHE)
+    WN_bat <- get("WN_bat", envir = .GRASS_CACHE)
+    if (get("SYS", envir = .GRASS_CACHE) == "WinNat" &&
+      (length(WN_bat) == 1L && nchar(WN_bat) == 0)) {
+      WN_bat <- sub(
+        ".bat", "",
+        list.files(paste(Sys.getenv("GISBASE"), "bin", sep = "/"),
+          pattern = ".bat$"
+        )
+      )
+      if (nchar(Sys.getenv("GRASS_ADDON_BASE")) > 0) {
+        t0 <- try(sub(
+          ".bat", "",
+          list.files(paste(Sys.getenv("GRASS_ADDON_BASE"),
+            "bin",
+            sep = "/"
+          ), pattern = ".bat$")
+        ), silent = TRUE)
+        if (length(t0) > 0 && !inherits(t0, "try-error") &&
+          is.character(t0) && all(nchar(t0) > 0))
+          WN_bat <- c(WN_bat, t0)
+      }
+      assign("WN_bat", WN_bat, envir = .GRASS_CACHE)
     }
-    if (is.null(res)) {
-        ext <- get("addEXE", envir=.GRASS_CACHE)
-        WN_bat <- get("WN_bat", envir=.GRASS_CACHE)
-        if (get("SYS", envir=.GRASS_CACHE) == "WinNat" &&
-            (length(WN_bat) == 1L && nchar(WN_bat) == 0)) {
-            WN_bat <- sub(".bat", "", 
-                list.files(paste(Sys.getenv("GISBASE"), "bin", sep="/"),
-                pattern=".bat$"))
-            if (nchar(Sys.getenv("GRASS_ADDON_BASE")) > 0) {
-                t0 <- try(sub(".bat", "", 
-                   list.files(paste(Sys.getenv("GRASS_ADDON_BASE"),
-                       "bin", sep="/"), pattern=".bat$")), silent=TRUE)
-                if (length(t0) > 0 && !inherits(t0, "try-error") &&
-                   is.character(t0) && all(nchar(t0) > 0))
-                   WN_bat <- c(WN_bat, t0)
-            }
-            assign("WN_bat", WN_bat, envir=.GRASS_CACHE)
-        } 
-        prep <- ""
-        if ((get("SYS", envir=.GRASS_CACHE) == "WinNat") &&
-            cmd %in% get("WN_bat", envir=.GRASS_CACHE))
-            ext <- ".bat"
+    prep <- ""
+    if ((get("SYS", envir = .GRASS_CACHE) == "WinNat") &&
+      cmd %in% get("WN_bat", envir = .GRASS_CACHE))
+      ext <- ".bat"
 
-        cmd0 <- paste(paste(prep, cmd, ext, sep=""), "--interface-description")
-        if (legacyExec) {
-            tr <- try(system(cmd0, intern=TRUE))
-	    if (inherits(tr, "try-error")) stop(paste(cmd, "not found"))
-        } else {
-            errFile <- tempfile()
-            outFile <- tempfile()
-            command <- paste(prep, cmd, ext, sep="")
-            arguments <- "--interface-description"
-            res <- system2(command=command, args=arguments, stdout=outFile,
-                stderr=errFile)
-            resErr <- readLines(errFile)
-            if (res == 127L) {
-               stop("The command\n", "   ", command, " ", arguments,
-                   "\ncould not be run (", res,
-                   "), and produced the error message:\n", "   ", resErr)
-            } else if (res == 1L) {
-                stop("The command\n", "   ", command, " ", arguments,
-                    "\nproduced an error (", res,
-                    ") during execution:\n", "   ", resErr)
-            }
-            tr <- readLines(outFile)
-        }
-        tr <- paste(tr, collapse=" ")
-        enc <- get("override_encoding", envir=.GRASS_CACHE)
-        if (nchar(enc) > 0) {
-#          if (length(grep("UTF-8", tr[1])) > 0) {
-#            tr[1] <- sub("UTF-8", enc, tr[1])
-#          }
-           tr <- try(xml2::read_xml(tr, encoding=enc))
-        } else {
-           tr <- try(xml2::read_xml(tr))
-        }
-#        tr <- try(xmlTreeParse(tr))
-	if (inherits(tr, "try-error")) stop(paste(cmd, "not parsed"))
-        tr1 <- xml2::xml_contents(xml2::xml_root(tr))
-#        tr1 <- xmlChildren(xmlRoot(tr))
-        res <- vector(mode="list", length=9)
-        names(res) <- c("cmd", "description", "keywords", "parameters", "flags",
-            "pnames", "fnames", "ext", "prep")
-        res$cmd <- cmd
-        res$ext <- ext
-        res$prep <- prep
-#        res$description <- xmlValue(tr1[[1]])
-        if (is.na(match("description", xml_name(tr1))))
-            res$description <- xml_text(tr1[[match("label", xml_name(tr1))]],
-                trim=TRUE)
-        else if (is.na(match("label", xml_name(tr1)))) 
-            res$description <- xml_text(tr1[[match("description",
-                xml_name(tr1))]], trim=TRUE)
-        else res$description <- paste0(xml_text(tr1[[match("label",
-                xml_name(tr1))]], trim=TRUE), " ", xml_text(tr1[[match(
-                "description", xml_name(tr1))]], trim=TRUE))
-#        res$keywords <- xmlValue(tr1[[2]])
-        res$keywords <- xml_text(tr1[[match("keywords", xml_name(tr1))]], trim=TRUE)
-#        o0 <- names(tr1)
-        o0 <- xml2::xml_name(tr1)
-        pseq <- which(o0 == "parameter")
-        np <- length(pseq)
-        ps <- vector(mode="list", length=np)
-        for (i in seq(along=pseq)) {
-            obj <- tr1[[pseq[i]]]
-            onms <- xml2::xml_name(xml2::xml_contents(obj))
-#            pv <- xmlAttrs(obj)
-            pv <- xml2::xml_attrs(obj)
-#            pvCh <- xmlChildren(obj)
-#            pv <- c(pv, xmlValue(pvCh[["description"]]))
-            pv <- c(pv, xml2::xml_text(xml2::xml_child(obj, "description"), trim=TRUE))
-#            default <- pvCh[["default"]]
-#            if (is.null(default)) {
-            if (!("default" %in% onms)) {
-                strdef <- as.character(NA)
-            } else {
-                strdef <- xml2::xml_text(xml2::xml_child(obj, "default"), trim=TRUE)
-                if (length(strdef) == 0) strdef <- ""
-            }
-            pv <- c(pv, strdef)
-#            kd <- pvCh[["keydesc"]]
-#            if (is.null(kd)) {
-            if (!("keydesc" %in% onms)) {
-                nkd <- as.integer(NA)
-                strkd <- as.character(NA)
-            } else {
-#                kda <- xmlApply(kd, xmlValue)
-                kda <- xml2::xml_child(obj, "keydesc")
-                kda <- xml2::xml_text(xml2::xml_children(kda), trim=TRUE)
-                nkd <- length(kda)
-                strkd <- paste(sapply(kda, c), collapse=",")
-            }
-            pv <- c(pv, nkd, strkd)
-#            names(pv) <- c(names(xmlAttrs(obj)), "desc", "default",
-            names(pv) <- c(names(xml2::xml_attrs(obj)), "desc", "default",
-                "keydesc_count", "keydesc")
-            ps[[i]] <- pv
-        }
-        res$parameters <- ps
-        fseq <- which(o0 == "flag")
-        nf <- length(fseq)
-        fs <- vector(mode="list", length=nf)
-        for (i in seq(along=fseq)) {
-            obj <- tr1[[fseq[i]]]
-#            fv <- xmlAttrs(obj)
-            fv <- xml2::xml_attrs(obj)
-# find description, don't assume first place 101206
-#            nobj <- sapply(xmlChildren(obj), xmlName)
-#            di <- match("description", nobj)
-#            fv <- c(fv, xmlValue(xmlChildren(obj)[[di]]))
-            fv <- c(fv, xml2::xml_text(xml2::xml_child(obj, "description"), trim=TRUE))
-#            suppr_req <- as.character("suppress_required" %in% nobj)
-            suppr_req <- as.character(!(is.na(xml2::xml_child(obj, "suppress_required"))))
-            fv <- c(fv, suppr_req)
-#            names(fv) <- c(names(xmlAttrs(obj)), "desc", "suppr_req")
-            names(fv) <- c(names(xml2::xml_attrs(obj)), "desc", "suppr_req")
-            fs[[i]] <- fv
-        }
-        res$flags <- fs
-        res$pnames <- sapply(res$parameters, function(x) x["name"])
-        names(res$pnames) <- NULL
-        res$fnames <- sapply(res$flags, function(x) x["name"])
-        names(res$fnames) <- NULL
-        class(res) <- "GRASS_interface_desc"
-        cmdCACHE[[cmd]] <- res
-        assign("cmdCACHE", cmdCACHE, envir=.GRASS_CACHE)
-    } 
-    res
-} 
+    cmd0 <- paste(paste(prep, cmd, ext, sep = ""), "--interface-description")
+    if (legacyExec) {
+      tr <- try(system(cmd0, intern = TRUE))
+      if (inherits(tr, "try-error")) stop(paste(cmd, "not found"))
+    } else {
+      errFile <- tempfile()
+      outFile <- tempfile()
+      command <- paste(prep, cmd, ext, sep = "")
+      arguments <- "--interface-description"
+      res <- system2(
+        command = command, args = arguments, stdout = outFile,
+        stderr = errFile
+      )
+      resErr <- readLines(errFile)
+      if (res == 127L) {
+        stop(
+          "The command\n", "   ", command, " ", arguments,
+          "\ncould not be run (", res,
+          "), and produced the error message:\n", "   ", resErr
+        )
+      } else if (res == 1L) {
+        stop(
+          "The command\n", "   ", command, " ", arguments,
+          "\nproduced an error (", res,
+          ") during execution:\n", "   ", resErr
+        )
+      }
+      tr <- readLines(outFile)
+    }
+    tr <- paste(tr, collapse = " ")
+    enc <- get("override_encoding", envir = .GRASS_CACHE)
+    if (nchar(enc) > 0) {
+      #          if (length(grep("UTF-8", tr[1])) > 0) {
+      #            tr[1] <- sub("UTF-8", enc, tr[1])
+      #          }
+      tr <- try(xml2::read_xml(tr, encoding = enc))
+    } else {
+      tr <- try(xml2::read_xml(tr))
+    }
+    #        tr <- try(xmlTreeParse(tr))
+    if (inherits(tr, "try-error")) stop(paste(cmd, "not parsed"))
+    tr1 <- xml2::xml_contents(xml2::xml_root(tr))
+    #        tr1 <- xmlChildren(xmlRoot(tr))
+    res <- vector(mode = "list", length = 9)
+    names(res) <- c(
+      "cmd", "description", "keywords", "parameters", "flags",
+      "pnames", "fnames", "ext", "prep"
+    )
+    res$cmd <- cmd
+    res$ext <- ext
+    res$prep <- prep
+    #        res$description <- xmlValue(tr1[[1]])
+    if (is.na(match("description", xml_name(tr1))))
+      res$description <- xml_text(tr1[[match("label", xml_name(tr1))]],
+        trim = TRUE
+      )
+    else if (is.na(match("label", xml_name(tr1))))
+      res$description <- xml_text(tr1[[match(
+        "description",
+        xml_name(tr1)
+      )]], trim = TRUE)
+    else res$description <- paste0(xml_text(tr1[[match(
+      "label",
+      xml_name(tr1)
+    )]], trim = TRUE), " ", xml_text(tr1[[match(
+      "description", xml_name(tr1)
+    )]], trim = TRUE))
+    #        res$keywords <- xmlValue(tr1[[2]])
+    res$keywords <- xml_text(tr1[[match("keywords", xml_name(tr1))]], trim = TRUE)
+    #        o0 <- names(tr1)
+    o0 <- xml2::xml_name(tr1)
+    pseq <- which(o0 == "parameter")
+    np <- length(pseq)
+    ps <- vector(mode = "list", length = np)
+    for (i in seq(along = pseq)) {
+      obj <- tr1[[pseq[i]]]
+      onms <- xml2::xml_name(xml2::xml_contents(obj))
+      #            pv <- xmlAttrs(obj)
+      pv <- xml2::xml_attrs(obj)
+      #            pvCh <- xmlChildren(obj)
+      #            pv <- c(pv, xmlValue(pvCh[["description"]]))
+      pv <- c(pv, xml2::xml_text(xml2::xml_child(obj, "description"), trim = TRUE))
+      #            default <- pvCh[["default"]]
+      #            if (is.null(default)) {
+      if (!("default" %in% onms)) {
+        strdef <- as.character(NA)
+      } else {
+        strdef <- xml2::xml_text(xml2::xml_child(obj, "default"), trim = TRUE)
+        if (length(strdef) == 0) strdef <- ""
+      }
+      pv <- c(pv, strdef)
+      #            kd <- pvCh[["keydesc"]]
+      #            if (is.null(kd)) {
+      if (!("keydesc" %in% onms)) {
+        nkd <- as.integer(NA)
+        strkd <- as.character(NA)
+      } else {
+        #                kda <- xmlApply(kd, xmlValue)
+        kda <- xml2::xml_child(obj, "keydesc")
+        kda <- xml2::xml_text(xml2::xml_children(kda), trim = TRUE)
+        nkd <- length(kda)
+        strkd <- paste(sapply(kda, c), collapse = ",")
+      }
+      pv <- c(pv, nkd, strkd)
+      #            names(pv) <- c(names(xmlAttrs(obj)), "desc", "default",
+      names(pv) <- c(
+        names(xml2::xml_attrs(obj)), "desc", "default",
+        "keydesc_count", "keydesc"
+      )
+      ps[[i]] <- pv
+    }
+    res$parameters <- ps
+    fseq <- which(o0 == "flag")
+    nf <- length(fseq)
+    fs <- vector(mode = "list", length = nf)
+    for (i in seq(along = fseq)) {
+      obj <- tr1[[fseq[i]]]
+      #            fv <- xmlAttrs(obj)
+      fv <- xml2::xml_attrs(obj)
+      # find description, don't assume first place 101206
+      #            nobj <- sapply(xmlChildren(obj), xmlName)
+      #            di <- match("description", nobj)
+      #            fv <- c(fv, xmlValue(xmlChildren(obj)[[di]]))
+      fv <- c(fv, xml2::xml_text(xml2::xml_child(obj, "description"), trim = TRUE))
+      #            suppr_req <- as.character("suppress_required" %in% nobj)
+      suppr_req <- as.character(!(is.na(xml2::xml_child(obj, "suppress_required"))))
+      fv <- c(fv, suppr_req)
+      #            names(fv) <- c(names(xmlAttrs(obj)), "desc", "suppr_req")
+      names(fv) <- c(names(xml2::xml_attrs(obj)), "desc", "suppr_req")
+      fs[[i]] <- fv
+    }
+    res$flags <- fs
+    res$pnames <- sapply(res$parameters, function(x) x["name"])
+    names(res$pnames) <- NULL
+    res$fnames <- sapply(res$flags, function(x) x["name"])
+    names(res$fnames) <- NULL
+    class(res) <- "GRASS_interface_desc"
+    cmdCACHE[[cmd]] <- res
+    assign("cmdCACHE", cmdCACHE, envir = .GRASS_CACHE)
+  }
+  res
+}
 
 setXMLencoding <- function(enc) {
   if (!is.character(enc) || length(enc) > 1)
     stop("enc must be a character string")
-  invisible(assign("override_encoding", enc, envir=.GRASS_CACHE))
+  invisible(assign("override_encoding", enc, envir = .GRASS_CACHE))
 }
 
 getXMLencoding <- function() {
- get("override_encoding", envir=.GRASS_CACHE)
+  get("override_encoding", envir = .GRASS_CACHE)
 }
 print.GRASS_interface_desc <- function(x, ...) {
-    cat("Command:", x$cmd, "\n")
-    if (nchar(x$ext) > 0) cat("Extension:", x$ext, "\n")
-    if (nchar(x$prep) > 0) cat("Shell prefix:", x$prep, "\n")
-    cat("Description:", x$description, "\n")
-    cat("Keywords:", x$keywords, "\n")
-    cat("Parameters:\n")
-    for (i in x$parameters) {
-        cat("  name: ", i["name"], ", type: ",
-            i["type"], ", required: ", i["required"], ", multiple: ",
-            i["multiple"], "\n", sep="")
-        if (!is.na(i["default"])) cat("  default: ", i["default"],
-            "\n", sep="")
-        if (!is.na(i["keydesc"])) cat("  keydesc: ", i["keydesc"],
-            ", keydesc_count: ", i["keydesc_count"], "\n", sep="")
-        cat("[", i["desc"], "]\n", sep="")
-    }
-    cat("Flags:\n")
-    for (i in x$flags) cat("  name: ", i["name"], " [",
-        i["desc"], "] {", i["suppr_req"], "}\n", sep="")
-    invisible(x)
+  cat("Command:", x$cmd, "\n")
+  if (nchar(x$ext) > 0) cat("Extension:", x$ext, "\n")
+  if (nchar(x$prep) > 0) cat("Shell prefix:", x$prep, "\n")
+  cat("Description:", x$description, "\n")
+  cat("Keywords:", x$keywords, "\n")
+  cat("Parameters:\n")
+  for (i in x$parameters) {
+    cat("  name: ", i["name"], ", type: ",
+      i["type"], ", required: ", i["required"], ", multiple: ",
+      i["multiple"], "\n",
+      sep = ""
+    )
+    if (!is.na(i["default"])) cat("  default: ", i["default"],
+      "\n",
+      sep = ""
+    )
+    if (!is.na(i["keydesc"])) cat("  keydesc: ", i["keydesc"],
+      ", keydesc_count: ", i["keydesc_count"], "\n",
+      sep = ""
+    )
+    cat("[", i["desc"], "]\n", sep = "")
+  }
+  cat("Flags:\n")
+  for (i in x$flags) cat("  name: ", i["name"], " [",
+    i["desc"], "] {", i["suppr_req"], "}\n",
+    sep = ""
+  )
+  invisible(x)
 }
 
-doGRASS <- function(cmd, flags=NULL, ..., parameters=NULL, echoCmd=NULL, legacyExec=NULL) {
-    defFlags <- get.defaultFlagsOption()
-    if (!is.null(defFlags)) flags <- unique(c(flags, defFlags))
-    if (all(c("quiet", "verbose") %in% flags)) {
-        flags <- flags[flags != "quiet"]
-    }
-    if (!is.null(flags)) stopifnot(is.character(flags))
-    if (!is.null(parameters)) stopifnot(is.list(parameters))
-    if (is.null(echoCmd))
-        echoCmd <- get("echoCmd", envir = .GRASS_CACHE)
-    stopifnot(is.logical(echoCmd))
-    if (is.null(legacyExec))
-        legacyExec <- get.legacyExecOption()
-    stopifnot(is.logical(legacyExec))
-    if (get("SYS", envir=.GRASS_CACHE) != "unix" && !legacyExec) {
-        warning("legacyExec set TRUE on non-unix platform")
-        legacyExec <- TRUE
-    }
+doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, legacyExec = NULL) {
+  defFlags <- get.defaultFlagsOption()
+  if (!is.null(defFlags)) flags <- unique(c(flags, defFlags))
+  if (all(c("quiet", "verbose") %in% flags)) {
+    flags <- flags[flags != "quiet"]
+  }
+  if (!is.null(flags)) stopifnot(is.character(flags))
+  if (!is.null(parameters)) stopifnot(is.list(parameters))
+  if (is.null(echoCmd))
+    echoCmd <- get("echoCmd", envir = .GRASS_CACHE)
+  stopifnot(is.logical(echoCmd))
+  if (is.null(legacyExec))
+    legacyExec <- get.legacyExecOption()
+  stopifnot(is.logical(legacyExec))
+  if (get("SYS", envir = .GRASS_CACHE) != "unix" && !legacyExec) {
+    warning("legacyExec set TRUE on non-unix platform")
+    legacyExec <- TRUE
+  }
 
-#    G6 <- get("GV", envir=.GRASS_CACHE) < "GRASS 7"
+  #    G6 <- get("GV", envir=.GRASS_CACHE) < "GRASS 7"
 
-    dlist <- list(...)
-    if (!is.null(parameters) && (length(dlist) > 0))
-        stop(paste("Use either GRASS parameters as R arguments,",
-        "or as a parameter argument list object, but not both", sep="\n"))
-    if (is.null(parameters) && (length(dlist) > 0)) parameters <- dlist
-    pcmd <- parseGRASS(cmd, legacyExec=legacyExec)
-    cmd <- paste(pcmd$prep, cmd, pcmd$ext, sep="")
-    res <- cmd
-    suppress_required <- FALSE
-    if (!is.null(flags)) {
-        fm <- match(flags, pcmd$fnames)
-        if (any(is.na(fm))) {
-            stop(paste(pcmd, "\nInvalid flag value:", flags[is.na(fm)]))
-        }
-        suppr_req <- as.logical(sapply(pcmd$flags, "[", "suppr_req"))
-        if (!suppress_required && any(suppr_req[fm])) suppress_required <- TRUE
-        dble_dash <- c("verbose", "overwrite", "quiet")
-        dbm <- na.omit(match(dble_dash, flags))
-        if (length(dbm) > 0) flags[dbm] <- paste("-", flags[dbm], sep="")
-        res <- paste(res, paste("-", flags, collapse=" ", sep=""))
+  dlist <- list(...)
+  if (!is.null(parameters) && (length(dlist) > 0))
+    stop(paste("Use either GRASS parameters as R arguments,",
+      "or as a parameter argument list object, but not both",
+      sep = "\n"
+    ))
+  if (is.null(parameters) && (length(dlist) > 0)) parameters <- dlist
+  pcmd <- parseGRASS(cmd, legacyExec = legacyExec)
+  cmd <- paste(pcmd$prep, cmd, pcmd$ext, sep = "")
+  res <- cmd
+  suppress_required <- FALSE
+  if (!is.null(flags)) {
+    fm <- match(flags, pcmd$fnames)
+    if (any(is.na(fm))) {
+      stop(paste(pcmd, "\nInvalid flag value:", flags[is.na(fm)]))
     }
-    pt <- do.call("rbind", pcmd$parameters)
-    req <- NULL
-    if (!is.null(pt)) {
-# g.version no parameters exception caught by Rainer M Krug 090923
-      req <- pt[pt[, "required"] != "no", "name"]
-# patch for multiple values Patrick Caldon 090524
-#      mult <- pt[pt[, "multiple"] != "no", "name"]
-# patch to accept no or multiple keydesc_count 090902
-      mults <- pt[, "multiple"] != "no" | (!is.na(pt[, "keydesc_count"]) &
-        pt[, "keydesc_count"] > 1)
-      mult <- pt[mults, "name"]
-      parameters <- insert_required(pcmd=pcmd, parameters=parameters,
-          pt=pt, req=req, suppress_required=suppress_required)
-      if (!suppress_required && length(req) > 0 && is.null(parameters)) {
-        stop(paste(pcmd, "\nNo parameters given where some are required with defaults declared"))
+    suppr_req <- as.logical(sapply(pcmd$flags, "[", "suppr_req"))
+    if (!suppress_required && any(suppr_req[fm])) suppress_required <- TRUE
+    dble_dash <- c("verbose", "overwrite", "quiet")
+    dbm <- na.omit(match(dble_dash, flags))
+    if (length(dbm) > 0) flags[dbm] <- paste("-", flags[dbm], sep = "")
+    res <- paste(res, paste("-", flags, collapse = " ", sep = ""))
+  }
+  pt <- do.call("rbind", pcmd$parameters)
+  req <- NULL
+  if (!is.null(pt)) {
+    # g.version no parameters exception caught by Rainer M Krug 090923
+    req <- pt[pt[, "required"] != "no", "name"]
+    # patch for multiple values Patrick Caldon 090524
+    #      mult <- pt[pt[, "multiple"] != "no", "name"]
+    # patch to accept no or multiple keydesc_count 090902
+    mults <- pt[, "multiple"] != "no" | (!is.na(pt[, "keydesc_count"]) &
+      pt[, "keydesc_count"] > 1)
+    mult <- pt[mults, "name"]
+    parameters <- insert_required(
+      pcmd = pcmd, parameters = parameters,
+      pt = pt, req = req, suppress_required = suppress_required
+    )
+    if (!suppress_required && length(req) > 0 && is.null(parameters)) {
+      stop(paste(pcmd, "\nNo parameters given where some are required with defaults declared"))
+    }
+    if (!is.null(parameters)) {
+      parnms <- names(parameters)
+      pm <- match(parnms, pcmd$pnames)
+      if (any(is.na(pm))) {
+        stop(paste(pcmd, "\nInvalid parameter name:", parnms[is.na(pm)]))
       }
-      if (!is.null(parameters)) {
-        parnms <- names(parameters)
-        pm <- match(parnms, pcmd$pnames)
-        if (any(is.na(pm))) {
-            stop(paste(pcmd, "\nInvalid parameter name:", parnms[is.na(pm)]))
+      if (!suppress_required && length(req) > 0) {
+        pmr <- match(req, parnms)
+        if (any(is.na(pmr))) {
+          stop(paste(pcmd, "\nMissing required parameter:", req[is.na(pmr)]))
         }
-        if (!suppress_required && length(req) > 0) {
-            pmr <- match(req, parnms)
-            if (any(is.na(pmr))) {
-                stop(paste(pcmd, "\nMissing required parameter:", req[is.na(pmr)]))
+      }
+      pmv <- pt[pm, "type"]
+      # patch for multiple values Patrick Caldon 090524
+      pmmult <- match(mult, parnms)
+      for (i in seq(along = parameters)) {
+        # patch for multiple values Patrick Caldon 090524
+        if (length(parameters[[i]]) > 1 && !(i %in% pmmult))
+          stop(paste("Parameter <", names(parameters)[i],
+            "> has multiple values",
+            sep = ""
+          ))
+        if (pmv[i] == "string") {
+          if (!is.character(parameters[[i]]))
+            stop(paste("Parameter <", names(parameters)[i],
+              "> does not have string value",
+              sep = ""
+            ))
+          # added any() 140516
+          if (any(is.na(parameters[[i]])))
+            stop(paste("Parameter <", names(parameters)[i],
+              "> is NA",
+              sep = ""
+            ))
+          # string space protection 091108 Martin Mainzer
+          Space <- length(grep(" ", parameters[[i]])) > 0
+          # Rainer Krug 110128
+          Paran <- length(grep("\\(", parameters[[i]])) > 0 ||
+            length(grep(")", parameters[[i]])) > 0
+          if (Space || Paran) {
+            # extra protection against existing escaping of quotes 100422
+            if (length(grep("\"", parameters[[i]])) == 0) {
+              parameters[[i]] <- paste("\"", parameters[[i]], "\"",
+                sep = ""
+              )
             }
-        }
-        pmv <- pt[pm, "type"]
-# patch for multiple values Patrick Caldon 090524
-        pmmult <- match(mult, parnms)
-        for (i in seq(along=parameters)) {
-# patch for multiple values Patrick Caldon 090524
-             if (length(parameters[[i]]) > 1 && !(i %in% pmmult))
-                stop(paste("Parameter <", names(parameters)[i],
-                    "> has multiple values", sep=""))
-            if (pmv[i] == "string") {
-                if (!is.character(parameters[[i]]))
-                    stop(paste("Parameter <", names(parameters)[i],
-                    "> does not have string value", sep=""))
-# added any() 140516
-                if (any(is.na(parameters[[i]])))
-                    stop(paste("Parameter <", names(parameters)[i],
-                    "> is NA", sep=""))
-# string space protection 091108 Martin Mainzer
-                Space <- length(grep(" ", parameters[[i]])) > 0
-# Rainer Krug 110128
-                Paran <- length(grep("\\(", parameters[[i]])) > 0 ||
-                    length(grep(")", parameters[[i]])) > 0
-                if (Space || Paran) {
-# extra protection against existing escaping of quotes 100422
-                  if (length(grep("\"", parameters[[i]])) == 0) {
-                    parameters[[i]] <- paste("\"", parameters[[i]], "\"",
-                        sep="")
-                  }
-                }
-            } else if (pmv[i] == "float") {
-                if (!is.numeric(parameters[[i]]))
-                    stop(paste("Parameter <", names(parameters)[i],
-                    "> does not have numeric value", sep=""))
-                if (any(!is.finite(parameters[[i]])))
-                    stop(paste("Parameter <", names(parameters)[i],
-                    "> is not finite", sep=""))
-            } else if (pmv[i] == "integer") {
-                if (!is.numeric(parameters[[i]]))
-                    stop(paste("Parameter <", names(parameters)[i],
-                    "> does not have numeric value", sep=""))
-                if (any(!is.finite(parameters[[i]])))
-                    stop(paste("Parameter <", names(parameters)[i],
-                    "> is not finite", sep=""))
-                if (!is.integer(parameters[[i]])) {
-                    opi <- parameters[[i]]
-                    if (all(as.integer(opi) == opi)) {
-                        parameters[[i]] <- as.integer(opi)
-                    } else {
-                        stop(paste("Parameter <", names(parameters)[i],
-                        "> is not integer", sep=""))
-                    }
-                }
-            } else warning("unknown parameter type")
-# patch for multiple values Patrick Caldon 090524
-            param <- paste(parameters[[i]], collapse=",")
-            res <- paste(res, paste(names(parameters)[i], param,
-                sep="="))
-        }
+          }
+        } else if (pmv[i] == "float") {
+          if (!is.numeric(parameters[[i]]))
+            stop(paste("Parameter <", names(parameters)[i],
+              "> does not have numeric value",
+              sep = ""
+            ))
+          if (any(!is.finite(parameters[[i]])))
+            stop(paste("Parameter <", names(parameters)[i],
+              "> is not finite",
+              sep = ""
+            ))
+        } else if (pmv[i] == "integer") {
+          if (!is.numeric(parameters[[i]]))
+            stop(paste("Parameter <", names(parameters)[i],
+              "> does not have numeric value",
+              sep = ""
+            ))
+          if (any(!is.finite(parameters[[i]])))
+            stop(paste("Parameter <", names(parameters)[i],
+              "> is not finite",
+              sep = ""
+            ))
+          if (!is.integer(parameters[[i]])) {
+            opi <- parameters[[i]]
+            if (all(as.integer(opi) == opi)) {
+              parameters[[i]] <- as.integer(opi)
+            } else {
+              stop(paste("Parameter <", names(parameters)[i],
+                "> is not integer",
+                sep = ""
+              ))
+            }
+          }
+        } else warning("unknown parameter type")
+        # patch for multiple values Patrick Caldon 090524
+        param <- paste(parameters[[i]], collapse = ",")
+        res <- paste(res, paste(names(parameters)[i], param,
+          sep = "="
+        ))
       }
     }
-    if (length(req) > 0) {
-      if ((!is.null(pt) && is.null(parameters)) && is.null(flags))
-        if (get.stop_on_no_flags_parasOption())
-            stop("No flags or parameters provided")
-        else warning("No flags or parameters provided")
-    }
-    if (echoCmd) cat("GRASS command:", res, "\n")
-    attr(res, "cmd") <- cmd
-    res
+  }
+  if (length(req) > 0) {
+    if ((!is.null(pt) && is.null(parameters)) && is.null(flags))
+      if (get.stop_on_no_flags_parasOption())
+        stop("No flags or parameters provided")
+      else warning("No flags or parameters provided")
+  }
+  if (echoCmd) cat("GRASS command:", res, "\n")
+  attr(res, "cmd") <- cmd
+  res
 }
 
 insert_required <- function(pcmd, parameters, pt, req, suppress_required) {
-    defs <- pt[match(req, pt[, "name"]), "default"]
-    nadefs <- which(is.na(defs))
-    nms <- pt[match(req, pt[, "name"]), "name"]
-    nadefnms <- nms[nadefs]
-    pnms <- names(parameters)
-    nadefnms1 <- nadefnms[is.na(match(nadefnms, pnms))]
-    if (!suppress_required && length(nadefnms1) > 0) {
-        stop(paste(pcmd, "\nrequired parameters with no defaults missing:",
-        paste(nadefnms1, collapse=" ")))
+  defs <- pt[match(req, pt[, "name"]), "default"]
+  nadefs <- which(is.na(defs))
+  nms <- pt[match(req, pt[, "name"]), "name"]
+  nadefnms <- nms[nadefs]
+  pnms <- names(parameters)
+  nadefnms1 <- nadefnms[is.na(match(nadefnms, pnms))]
+  if (!suppress_required && length(nadefnms1) > 0) {
+    stop(paste(
+      pcmd, "\nrequired parameters with no defaults missing:",
+      paste(nadefnms1, collapse = " ")
+    ))
+  }
+  types <- pt[match(req, pt[, "name"]), "type"]
+  defnms <- nms[!is.na(defs)]
+  deftypes <- types[!is.na(defs)]
+  defdefs <- defs[!is.na(defs)]
+  if (is.null(parameters)) parameters <- list()
+  for (i in seq(along = defnms)) {
+    if (!(defnms[i] %in% pnms)) {
+      parameters[[defnms[i]]] <- switch(deftypes[i],
+        integer = as.integer(defdefs[i]),
+        float = as.numeric(defdefs[i]),
+        string = defdefs[i]
+      )
     }
-    types <- pt[match(req, pt[, "name"]), "type"]
-    defnms <- nms[!is.na(defs)]
-    deftypes <- types[!is.na(defs)]
-    defdefs <- defs[!is.na(defs)]
-    if (is.null(parameters)) parameters <- list()
-    for (i in seq(along=defnms)) {
-        if (!(defnms[i] %in% pnms)) {
-            parameters[[defnms[i]]] <- switch(deftypes[i],
-                integer = as.integer(defdefs[i]),
-                float = as.numeric(defdefs[i]),
-                string = defdefs[i])
-        }
-    }
-    if (length(parameters) == 0) parameters <- NULL
-    parameters
+  }
+  if (length(parameters) == 0) parameters <- NULL
+  parameters
 }
 
-execGRASS <- function(cmd, flags=NULL, ..., parameters=NULL, intern=NULL,
-    ignore.stderr=NULL, Sys_ignore.stdout=FALSE, Sys_wait=TRUE,
-    Sys_input=NULL, Sys_show.output.on.console=TRUE, Sys_minimized=FALSE,
-    Sys_invisible=TRUE, echoCmd=NULL, redirect=FALSE, legacyExec=NULL) {
-    if (is.null(ignore.stderr))
-        ignore.stderr <- get.ignore.stderrOption()
-    stopifnot(is.logical(ignore.stderr))
-    if (is.null(intern))
-        intern <- get.useInternOption()
-    stopifnot(is.logical(intern))
-    if (is.null(legacyExec))
-        legacyExec <- get.legacyExecOption()
-    stopifnot(is.logical(legacyExec))
-    if (get("SYS", envir=.GRASS_CACHE) != "unix" && !legacyExec) {
-        warning("legacyExec set TRUE on non-unix platform")
-       legacyExec <- TRUE
-    }
+execGRASS <- function(
+    cmd, flags = NULL, ..., parameters = NULL, intern = NULL,
+    ignore.stderr = NULL, Sys_ignore.stdout = FALSE, Sys_wait = TRUE,
+    Sys_input = NULL, Sys_show.output.on.console = TRUE, Sys_minimized = FALSE,
+    Sys_invisible = TRUE, echoCmd = NULL, redirect = FALSE, legacyExec = NULL) {
+  if (is.null(ignore.stderr))
+    ignore.stderr <- get.ignore.stderrOption()
+  stopifnot(is.logical(ignore.stderr))
+  if (is.null(intern))
+    intern <- get.useInternOption()
+  stopifnot(is.logical(intern))
+  if (is.null(legacyExec))
+    legacyExec <- get.legacyExecOption()
+  stopifnot(is.logical(legacyExec))
+  if (get("SYS", envir = .GRASS_CACHE) != "unix" && !legacyExec) {
+    warning("legacyExec set TRUE on non-unix platform")
+    legacyExec <- TRUE
+  }
 
-    syscmd <- doGRASS(cmd, flags=flags, ..., parameters=parameters,
-        echoCmd=echoCmd, legacyExec=legacyExec)
-    if (legacyExec) {
-        if (redirect) {
-            syscmd <- paste(syscmd, "2>&1")
-            intern=TRUE
-        }
-        if (get("SYS", envir=.GRASS_CACHE) == "unix") {
-            res <- system(syscmd, intern=intern, ignore.stderr=ignore.stderr,
-                ignore.stdout=Sys_ignore.stdout, wait=Sys_wait, input=Sys_input)
-        } else {
-            res <- system(syscmd, intern=intern, ignore.stderr=ignore.stderr,
-                ignore.stdout=Sys_ignore.stdout, wait=Sys_wait, input=Sys_input,
-                show.output.on.console=Sys_show.output.on.console, 
-                minimized=Sys_minimized, invisible=Sys_invisible)
-        }
-        if (intern) return(res)
+  syscmd <- doGRASS(cmd,
+    flags = flags, ..., parameters = parameters,
+    echoCmd = echoCmd, legacyExec = legacyExec
+  )
+  if (legacyExec) {
+    if (redirect) {
+      syscmd <- paste(syscmd, "2>&1")
+      intern = TRUE
+    }
+    if (get("SYS", envir = .GRASS_CACHE) == "unix") {
+      res <- system(syscmd,
+        intern = intern, ignore.stderr = ignore.stderr,
+        ignore.stdout = Sys_ignore.stdout, wait = Sys_wait, input = Sys_input
+      )
     } else {
-        command <- attr(syscmd, "cmd")
-        arguments <- substring(syscmd, (nchar(command)+2), nchar(syscmd))
-
-        errFile <- tempfile(fileext=".err")
-        outFile <- tempfile(fileext=".out")
-
-        res <- system2(command, arguments, stderr = errFile,
-            stdout = outFile, wait=Sys_wait, input=Sys_input)
-
-        resErr <- readLines(errFile)
-        if (res == 127L) {
-             stop("The command:\n", command, " ", arguments,
-                 "\ncould not be run (", res,
-                 "), and produced the error message:\n",
-                 paste(resErr, collapse="\n"))
-        } else if (res == 1L) {
-            stop("The command:\n", command, " ", arguments,
-                "\nproduced an error (", res,
-                ") during execution:\n", paste(resErr, collapse="\n"))
-        } else if (res == 0L & !ignore.stderr) {
-            if (length(grep("ERROR:", resErr)) > 0) {
-                stop("The command:\n", command, " ", arguments,
-                    "\nproduced an error (", res,
-                    ") during execution:\n",
-                    paste(resErr, collapse="\n"))
-            } else if (length(grep("WARNING:", resErr)) > 0) {
-                warning("The command:\n", command, " ", arguments,
-                    "\nproduced at least one warning during execution:\n",
-                    paste(resErr, collapse="\n"))
-            }
-        }
-
-        resOut <- readLines(outFile)
-        if (intern) return(resOut)
-
-        if (length(resOut) > 0) cat(resOut, sep="\n")
-        if (length(resErr) > 0) cat(resErr, sep="\n")
-       
-        attr(res, "resOut") <- resOut
-        attr(res, "resErr") <- resErr
+      res <- system(syscmd,
+        intern = intern, ignore.stderr = ignore.stderr,
+        ignore.stdout = Sys_ignore.stdout, wait = Sys_wait, input = Sys_input,
+        show.output.on.console = Sys_show.output.on.console,
+        minimized = Sys_minimized, invisible = Sys_invisible
+      )
     }
-    if (cmd == "g.gui") message("WX GUI launched - Close GUI manually when finished")
-    invisible(res)
+    if (intern) return(res)
+  } else {
+    command <- attr(syscmd, "cmd")
+    arguments <- substring(syscmd, (nchar(command) + 2), nchar(syscmd))
+
+    errFile <- tempfile(fileext = ".err")
+    outFile <- tempfile(fileext = ".out")
+
+    res <- system2(command, arguments,
+      stderr = errFile,
+      stdout = outFile, wait = Sys_wait, input = Sys_input
+    )
+
+    resErr <- readLines(errFile)
+    if (res == 127L) {
+      stop(
+        "The command:\n", command, " ", arguments,
+        "\ncould not be run (", res,
+        "), and produced the error message:\n",
+        paste(resErr, collapse = "\n")
+      )
+    } else if (res == 1L) {
+      stop(
+        "The command:\n", command, " ", arguments,
+        "\nproduced an error (", res,
+        ") during execution:\n", paste(resErr, collapse = "\n")
+      )
+    } else if (res == 0L & !ignore.stderr) {
+      if (length(grep("ERROR:", resErr)) > 0) {
+        stop(
+          "The command:\n", command, " ", arguments,
+          "\nproduced an error (", res,
+          ") during execution:\n",
+          paste(resErr, collapse = "\n")
+        )
+      } else if (length(grep("WARNING:", resErr)) > 0) {
+        warning(
+          "The command:\n", command, " ", arguments,
+          "\nproduced at least one warning during execution:\n",
+          paste(resErr, collapse = "\n")
+        )
+      }
+    }
+
+    resOut <- readLines(outFile)
+    if (intern) return(resOut)
+
+    if (length(resOut) > 0) cat(resOut, sep = "\n")
+    if (length(resErr) > 0) cat(resErr, sep = "\n")
+
+    attr(res, "resOut") <- resOut
+    attr(res, "resErr") <- resErr
+  }
+  if (cmd == "g.gui") message("WX GUI launched - Close GUI manually when finished")
+  invisible(res)
 }
 
-stringexecGRASS <- function(string, 
-                            intern=NULL,
-                            ignore.stderr=NULL, 
-                            Sys_ignore.stdout=FALSE, 
-                            Sys_wait=TRUE,
-                            Sys_input=NULL, 
-                            Sys_show.output.on.console=TRUE, 
-                            Sys_minimized=FALSE,
-                            Sys_invisible=TRUE, 
-                            echoCmd=NULL, 
-                            redirect=FALSE, 
-                            legacyExec=NULL) {
+stringexecGRASS <- function(string,
+                            intern = NULL,
+                            ignore.stderr = NULL,
+                            Sys_ignore.stdout = FALSE,
+                            Sys_wait = TRUE,
+                            Sys_input = NULL,
+                            Sys_show.output.on.console = TRUE,
+                            Sys_minimized = FALSE,
+                            Sys_invisible = TRUE,
+                            echoCmd = NULL,
+                            redirect = FALSE,
+                            legacyExec = NULL) {
   stopifnot(is.character(string) && length(string) == 1)
   # extract quoted parameters
-  quoted_params <- regmatches(string, 
-                              gregexpr("\\w+=['\"].*?['\"]", string))[[1]]
+  quoted_params <- regmatches(
+    string,
+    gregexpr("\\w+=['\"].*?['\"]", string)
+  )[[1]]
   if (length(quoted_params) > 0) {
-    names(quoted_params) <- regmatches(quoted_params, 
-                                       regexpr("^\\w+", quoted_params))
-    quoted_params <- regmatches(quoted_params, 
-                                regexpr("(?<==['\"]).+(?=['\"]$)", 
-                                        quoted_params, 
-                                        perl = TRUE))
+    names(quoted_params) <- regmatches(
+      quoted_params,
+      regexpr("^\\w+", quoted_params)
+    )
+    quoted_params <- regmatches(
+      quoted_params,
+      regexpr("(?<==['\"]).+(?=['\"]$)",
+        quoted_params,
+        perl = TRUE
+      )
+    )
     quoted_params <- as.list(quoted_params)
   }
   # split remaining parts into cmd, flags and simple parameters
   components <- strsplit(gsub("\\w+=['\"].*?['\"]", "", string), "\\s+")[[1]]
   cmd <- components[1]
   if (!grepl("^\\w{1,2}\\.\\w+(\\.\\w+)*$", cmd)) {
-    stop("The string argument of stringexecGRASS() ",
-         "must begin with a valid GRASS command name.")
+    stop(
+      "The string argument of stringexecGRASS() ",
+      "must begin with a valid GRASS command name."
+    )
   }
   pattern_flag <- "^-+"
   flags <- grep(pattern_flag, components, value = TRUE)
   if (length(flags) > 0) {
     flags <- sub(pattern_flag, "", flags)
-    } else {
+  } else {
     flags <- NULL
   }
   simple_params <- grep("^\\w+=", components, value = TRUE)
   if (length(simple_params) > 0) {
-    names(simple_params) <- regmatches(simple_params, 
-                                       regexpr("^\\w+", simple_params))
-    simple_params <- regmatches(simple_params, 
-                                regexpr("(?<==).+$", 
-                                        simple_params, 
-                                        perl = TRUE))
+    names(simple_params) <- regmatches(
+      simple_params,
+      regexpr("^\\w+", simple_params)
+    )
+    simple_params <- regmatches(
+      simple_params,
+      regexpr("(?<==).+$",
+        simple_params,
+        perl = TRUE
+      )
+    )
     simple_params <- as.list(simple_params)
-    simple_params[grep("^[+-]?(\\d*\\.)?\\d+$", simple_params)] <- 
+    simple_params[grep("^[+-]?(\\d*\\.)?\\d+$", simple_params)] <-
       as.numeric(simple_params[grep("^[+-]?(\\d*\\.)?\\d+$", simple_params)])
   }
   # combine simple and quoted parameters
@@ -497,33 +584,35 @@ stringexecGRASS <- function(string,
     parameters <- NULL
   }
   # non-processed parts of 'components' will lead to an error
-  if (length(flags) + length(parameters) + 1 != 
-      length(components) + length(quoted_params)) {
-    stop("stringexecGRASS() could not successfully split the provided string ",
-         "into ONE command name plus (optionally) flags and parameters.\n",
-         "Please check syntax:\n",
-         "- the command name, flags and parameters must be separated by ",
-         "a whitespace\n",
-         "- each parameter must be of the form key=value; ",
-         "if 'value' contains spaces, then 'value' must be quoted\n",
-         "- concatenation of flags (as in 'g.proj -wf') is not supported: ",
-         "use 'g.proj -w -f'\n",
-         "- the command name must come at the beginning\n")
+  if (length(flags) + length(parameters) + 1 !=
+    length(components) + length(quoted_params)) {
+    stop(
+      "stringexecGRASS() could not successfully split the provided string ",
+      "into ONE command name plus (optionally) flags and parameters.\n",
+      "Please check syntax:\n",
+      "- the command name, flags and parameters must be separated by ",
+      "a whitespace\n",
+      "- each parameter must be of the form key=value; ",
+      "if 'value' contains spaces, then 'value' must be quoted\n",
+      "- concatenation of flags (as in 'g.proj -wf') is not supported: ",
+      "use 'g.proj -w -f'\n",
+      "- the command name must come at the beginning\n"
+    )
   }
-  execGRASS(cmd = cmd, 
-            flags=flags, 
-            parameters=parameters, 
-            intern=intern,
-            ignore.stderr=ignore.stderr,
-            Sys_ignore.stdout=Sys_ignore.stdout,
-            Sys_wait=Sys_wait,
-            Sys_input=Sys_input,
-            Sys_show.output.on.console=Sys_show.output.on.console,
-            Sys_minimized=Sys_minimized,
-            Sys_invisible=Sys_invisible,
-            echoCmd=echoCmd,
-            redirect=redirect,
-            legacyExec=legacyExec)
+  execGRASS(
+    cmd = cmd,
+    flags = flags,
+    parameters = parameters,
+    intern = intern,
+    ignore.stderr = ignore.stderr,
+    Sys_ignore.stdout = Sys_ignore.stdout,
+    Sys_wait = Sys_wait,
+    Sys_input = Sys_input,
+    Sys_show.output.on.console = Sys_show.output.on.console,
+    Sys_minimized = Sys_minimized,
+    Sys_invisible = Sys_invisible,
+    echoCmd = echoCmd,
+    redirect = redirect,
+    legacyExec = legacyExec
+  )
 }
-
-

--- a/R/xml1.R
+++ b/R/xml1.R
@@ -1,8 +1,9 @@
 parseGRASS <- function(cmd, legacyExec = NULL) {
   cmdCACHE <- get("cmdCACHE", envir = .GRASS_CACHE)
   res <- cmdCACHE[[cmd]]
-  if (is.null(legacyExec))
+  if (is.null(legacyExec)) {
     legacyExec <- get.legacyExecOption()
+  }
   stopifnot(is.logical(legacyExec))
   if (get("SYS", envir = .GRASS_CACHE) != "unix" && !legacyExec) {
     warning("legacyExec set TRUE on non-unix platform")
@@ -28,15 +29,17 @@ parseGRASS <- function(cmd, legacyExec = NULL) {
           ), pattern = ".bat$")
         ), silent = TRUE)
         if (length(t0) > 0 && !inherits(t0, "try-error") &&
-          is.character(t0) && all(nchar(t0) > 0))
+          is.character(t0) && all(nchar(t0) > 0)) {
           WN_bat <- c(WN_bat, t0)
+        }
       }
       assign("WN_bat", WN_bat, envir = .GRASS_CACHE)
     }
     prep <- ""
     if ((get("SYS", envir = .GRASS_CACHE) == "WinNat") &&
-      cmd %in% get("WN_bat", envir = .GRASS_CACHE))
+      cmd %in% get("WN_bat", envir = .GRASS_CACHE)) {
       ext <- ".bat"
+    }
 
     cmd0 <- paste(paste(prep, cmd, ext, sep = ""), "--interface-description")
     if (legacyExec) {
@@ -90,21 +93,23 @@ parseGRASS <- function(cmd, legacyExec = NULL) {
     res$ext <- ext
     res$prep <- prep
     #        res$description <- xmlValue(tr1[[1]])
-    if (is.na(match("description", xml_name(tr1))))
+    if (is.na(match("description", xml_name(tr1)))) {
       res$description <- xml_text(tr1[[match("label", xml_name(tr1))]],
         trim = TRUE
       )
-    else if (is.na(match("label", xml_name(tr1))))
+    } else if (is.na(match("label", xml_name(tr1)))) {
       res$description <- xml_text(tr1[[match(
         "description",
         xml_name(tr1)
       )]], trim = TRUE)
-    else res$description <- paste0(xml_text(tr1[[match(
-      "label",
-      xml_name(tr1)
-    )]], trim = TRUE), " ", xml_text(tr1[[match(
-      "description", xml_name(tr1)
-    )]], trim = TRUE))
+    } else {
+      res$description <- paste0(xml_text(tr1[[match(
+        "label",
+        xml_name(tr1)
+      )]], trim = TRUE), " ", xml_text(tr1[[match(
+        "description", xml_name(tr1)
+      )]], trim = TRUE))
+    }
     #        res$keywords <- xmlValue(tr1[[2]])
     res$keywords <- xml_text(tr1[[match("keywords", xml_name(tr1))]], trim = TRUE)
     #        o0 <- names(tr1)
@@ -182,8 +187,9 @@ parseGRASS <- function(cmd, legacyExec = NULL) {
 }
 
 setXMLencoding <- function(enc) {
-  if (!is.character(enc) || length(enc) > 1)
+  if (!is.character(enc) || length(enc) > 1) {
     stop("enc must be a character string")
+  }
   invisible(assign("override_encoding", enc, envir = .GRASS_CACHE))
 }
 
@@ -203,21 +209,27 @@ print.GRASS_interface_desc <- function(x, ...) {
       i["multiple"], "\n",
       sep = ""
     )
-    if (!is.na(i["default"])) cat("  default: ", i["default"],
-      "\n",
-      sep = ""
-    )
-    if (!is.na(i["keydesc"])) cat("  keydesc: ", i["keydesc"],
-      ", keydesc_count: ", i["keydesc_count"], "\n",
-      sep = ""
-    )
+    if (!is.na(i["default"])) {
+      cat("  default: ", i["default"],
+        "\n",
+        sep = ""
+      )
+    }
+    if (!is.na(i["keydesc"])) {
+      cat("  keydesc: ", i["keydesc"],
+        ", keydesc_count: ", i["keydesc_count"], "\n",
+        sep = ""
+      )
+    }
     cat("[", i["desc"], "]\n", sep = "")
   }
   cat("Flags:\n")
-  for (i in x$flags) cat("  name: ", i["name"], " [",
-    i["desc"], "] {", i["suppr_req"], "}\n",
-    sep = ""
-  )
+  for (i in x$flags) {
+    cat("  name: ", i["name"], " [",
+      i["desc"], "] {", i["suppr_req"], "}\n",
+      sep = ""
+    )
+  }
   invisible(x)
 }
 
@@ -229,11 +241,13 @@ doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, l
   }
   if (!is.null(flags)) stopifnot(is.character(flags))
   if (!is.null(parameters)) stopifnot(is.list(parameters))
-  if (is.null(echoCmd))
+  if (is.null(echoCmd)) {
     echoCmd <- get("echoCmd", envir = .GRASS_CACHE)
+  }
   stopifnot(is.logical(echoCmd))
-  if (is.null(legacyExec))
+  if (is.null(legacyExec)) {
     legacyExec <- get.legacyExecOption()
+  }
   stopifnot(is.logical(legacyExec))
   if (get("SYS", envir = .GRASS_CACHE) != "unix" && !legacyExec) {
     warning("legacyExec set TRUE on non-unix platform")
@@ -243,11 +257,12 @@ doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, l
   #    G6 <- get("GV", envir=.GRASS_CACHE) < "GRASS 7"
 
   dlist <- list(...)
-  if (!is.null(parameters) && (length(dlist) > 0))
+  if (!is.null(parameters) && (length(dlist) > 0)) {
     stop(paste("Use either GRASS parameters as R arguments,",
       "or as a parameter argument list object, but not both",
       sep = "\n"
     ))
+  }
   if (is.null(parameters) && (length(dlist) > 0)) parameters <- dlist
   pcmd <- parseGRASS(cmd, legacyExec = legacyExec)
   cmd <- paste(pcmd$prep, cmd, pcmd$ext, sep = "")
@@ -300,23 +315,26 @@ doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, l
       pmmult <- match(mult, parnms)
       for (i in seq(along = parameters)) {
         # patch for multiple values Patrick Caldon 090524
-        if (length(parameters[[i]]) > 1 && !(i %in% pmmult))
+        if (length(parameters[[i]]) > 1 && !(i %in% pmmult)) {
           stop(paste("Parameter <", names(parameters)[i],
             "> has multiple values",
             sep = ""
           ))
+        }
         if (pmv[i] == "string") {
-          if (!is.character(parameters[[i]]))
+          if (!is.character(parameters[[i]])) {
             stop(paste("Parameter <", names(parameters)[i],
               "> does not have string value",
               sep = ""
             ))
+          }
           # added any() 140516
-          if (any(is.na(parameters[[i]])))
+          if (any(is.na(parameters[[i]]))) {
             stop(paste("Parameter <", names(parameters)[i],
               "> is NA",
               sep = ""
             ))
+          }
           # string space protection 091108 Martin Mainzer
           Space <- length(grep(" ", parameters[[i]])) > 0
           # Rainer Krug 110128
@@ -331,27 +349,31 @@ doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, l
             }
           }
         } else if (pmv[i] == "float") {
-          if (!is.numeric(parameters[[i]]))
+          if (!is.numeric(parameters[[i]])) {
             stop(paste("Parameter <", names(parameters)[i],
               "> does not have numeric value",
               sep = ""
             ))
-          if (any(!is.finite(parameters[[i]])))
+          }
+          if (any(!is.finite(parameters[[i]]))) {
             stop(paste("Parameter <", names(parameters)[i],
               "> is not finite",
               sep = ""
             ))
+          }
         } else if (pmv[i] == "integer") {
-          if (!is.numeric(parameters[[i]]))
+          if (!is.numeric(parameters[[i]])) {
             stop(paste("Parameter <", names(parameters)[i],
               "> does not have numeric value",
               sep = ""
             ))
-          if (any(!is.finite(parameters[[i]])))
+          }
+          if (any(!is.finite(parameters[[i]]))) {
             stop(paste("Parameter <", names(parameters)[i],
               "> is not finite",
               sep = ""
             ))
+          }
           if (!is.integer(parameters[[i]])) {
             opi <- parameters[[i]]
             if (all(as.integer(opi) == opi)) {
@@ -363,7 +385,9 @@ doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, l
               ))
             }
           }
-        } else warning("unknown parameter type")
+        } else {
+          warning("unknown parameter type")
+        }
         # patch for multiple values Patrick Caldon 090524
         param <- paste(parameters[[i]], collapse = ",")
         res <- paste(res, paste(names(parameters)[i], param,
@@ -373,10 +397,13 @@ doGRASS <- function(cmd, flags = NULL, ..., parameters = NULL, echoCmd = NULL, l
     }
   }
   if (length(req) > 0) {
-    if ((!is.null(pt) && is.null(parameters)) && is.null(flags))
-      if (get.stop_on_no_flags_parasOption())
+    if ((!is.null(pt) && is.null(parameters)) && is.null(flags)) {
+      if (get.stop_on_no_flags_parasOption()) {
         stop("No flags or parameters provided")
-      else warning("No flags or parameters provided")
+      } else {
+        warning("No flags or parameters provided")
+      }
+    }
   }
   if (echoCmd) cat("GRASS command:", res, "\n")
   attr(res, "cmd") <- cmd
@@ -419,14 +446,17 @@ execGRASS <- function(
     ignore.stderr = NULL, Sys_ignore.stdout = FALSE, Sys_wait = TRUE,
     Sys_input = NULL, Sys_show.output.on.console = TRUE, Sys_minimized = FALSE,
     Sys_invisible = TRUE, echoCmd = NULL, redirect = FALSE, legacyExec = NULL) {
-  if (is.null(ignore.stderr))
+  if (is.null(ignore.stderr)) {
     ignore.stderr <- get.ignore.stderrOption()
+  }
   stopifnot(is.logical(ignore.stderr))
-  if (is.null(intern))
+  if (is.null(intern)) {
     intern <- get.useInternOption()
+  }
   stopifnot(is.logical(intern))
-  if (is.null(legacyExec))
+  if (is.null(legacyExec)) {
     legacyExec <- get.legacyExecOption()
+  }
   stopifnot(is.logical(legacyExec))
   if (get("SYS", envir = .GRASS_CACHE) != "unix" && !legacyExec) {
     warning("legacyExec set TRUE on non-unix platform")
@@ -440,7 +470,7 @@ execGRASS <- function(
   if (legacyExec) {
     if (redirect) {
       syscmd <- paste(syscmd, "2>&1")
-      intern = TRUE
+      intern <- TRUE
     }
     if (get("SYS", envir = .GRASS_CACHE) == "unix") {
       res <- system(syscmd,
@@ -455,7 +485,9 @@ execGRASS <- function(
         minimized = Sys_minimized, invisible = Sys_invisible
       )
     }
-    if (intern) return(res)
+    if (intern) {
+      return(res)
+    }
   } else {
     command <- attr(syscmd, "cmd")
     arguments <- substring(syscmd, (nchar(command) + 2), nchar(syscmd))
@@ -500,7 +532,9 @@ execGRASS <- function(
     }
 
     resOut <- readLines(outFile)
-    if (intern) return(resOut)
+    if (intern) {
+      return(resOut)
+    }
 
     if (length(resOut) > 0) cat(resOut, sep = "\n")
     if (length(resErr) > 0) cat(resErr, sep = "\n")

--- a/man/readRAST.Rd
+++ b/man/readRAST.Rd
@@ -4,7 +4,7 @@
 \alias{write_RAST}
 \title{Read and write GRASS raster files}
 \description{
-Read GRASS raster files from GRASS into R \pkg{terra} \code{"SpatRaster"} or \pkg{sp} \code{"SpatialGridDataFrame"} objects, and write single columns of \pkg{terra} \code{"SpatRaster"} or \pkg{sp} \code{"SpatialGridDataFrame"} objects to GRASS. When \code{return_format="terra"}, temporary binary files and r.out.bin and r.in.bin are used for speed reasons. \code{read_RAST()} and \code{write_RAST()} by default use \code{"RRASTER"} files written and read by GDAL. 
+Read GRASS raster files from GRASS into R \pkg{terra} \code{"SpatRaster"} or \pkg{sp} \code{"SpatialGridDataFrame"} objects, and write single columns of \pkg{terra} \code{"SpatRaster"} or \pkg{sp} \code{"SpatialGridDataFrame"} objects to GRASS. When \code{return_format="terra"}, temporary binary files and r.out.bin and r.in.bin are used for speed reasons. \code{read_RAST()} and \code{write_RAST()} by default use \code{"RRASTER"} files written and read by GDAL.
 }
 
 
@@ -12,7 +12,7 @@ Read GRASS raster files from GRASS into R \pkg{terra} \code{"SpatRaster"} or \pk
 \usage{
 read_RAST(vname, cat=NULL, NODATA=NULL, ignore.stderr=get.ignore.stderrOption(),
  return_format="terra", close_OK=return_format=="SGDF", flags=NULL)
-write_RAST(x, vname, zcol = 1, NODATA=NULL, flags=NULL, 
+write_RAST(x, vname, zcol = 1, NODATA=NULL, flags=NULL,
  ignore.stderr = get.ignore.stderrOption(), overwrite=FALSE, verbose=TRUE)
 }
 %- maybe also 'usage' for other objects documented here.

--- a/man/readRAST.Rd
+++ b/man/readRAST.Rd
@@ -100,7 +100,7 @@ if (run) {
   try(sqdem1 <- read_RAST(c("sqdemSP@rsb", "elevation@PERMANENT")))
 }
 if (run) {
-names(sqdem1)
+  try(names(sqdem1))
 }
 if (run) {
   execGRASS("g.remove", flags="f", name="sqdemSP", type="raster")

--- a/tests/test_XML_xml2.R
+++ b/tests/test_XML_xml2.R
@@ -1,10 +1,10 @@
 library(rgrass)
-old <- readRDS(system.file("etc/XML.r.out.gdal.rds", package="rgrass"))
+old <- readRDS(system.file("etc/XML.r.out.gdal.rds", package = "rgrass"))
 if (nchar(Sys.getenv("GISRC")) > 0) {
   new <- parseGRASS("r.out.gdal")
   all.equal(old, new)
 }
-old <- readRDS(system.file("etc/res_r.water.outlet.rds", package="rgrass"))
+old <- readRDS(system.file("etc/res_r.water.outlet.rds", package = "rgrass"))
 if (nchar(Sys.getenv("GISRC")) > 0) {
   new <- parseGRASS("r.water.outlet")
   all.equal(old, new)

--- a/tests/test_terra_ptr.R
+++ b/tests/test_terra_ptr.R
@@ -1,6 +1,6 @@
 library(rgrass)
-if (requireNamespace("terra", quietly=TRUE)) {
-  f <- system.file("ex/elev.tif", package="terra")
+if (requireNamespace("terra", quietly = TRUE)) {
+  f <- system.file("ex/elev.tif", package = "terra")
   SG <- terra::rast(f)
   if (packageVersion("terra") < "1.7.46") {
     bb <- getMethod("ext", "SpatRaster")(SG)@ptr$vector

--- a/vignettes/coerce.Rmd
+++ b/vignettes/coerce.Rmd
@@ -16,7 +16,7 @@ vignette: >
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE, paged.print=FALSE)
+knitr::opts_chunk$set(echo = TRUE, paged.print = FALSE)
 ```
 
 ## Introduction
@@ -46,11 +46,11 @@ This vignette is constructed conditioning on the availability of aforementioned 
 
 
 ```{r include=FALSE, message=FALSE}
-terra_available <- requireNamespace("terra", quietly=TRUE)
-sf_available <- requireNamespace("sf", quietly=TRUE)
-sp_available <- requireNamespace("sp", quietly=TRUE)
-stars_available <- requireNamespace("stars", quietly=TRUE) && packageVersion("stars") > "0.5.4"
-raster_available <- requireNamespace("raster", quietly=TRUE)
+terra_available <- requireNamespace("terra", quietly = TRUE)
+sf_available <- requireNamespace("sf", quietly = TRUE)
+sp_available <- requireNamespace("sp", quietly = TRUE)
+stars_available <- requireNamespace("stars", quietly = TRUE) && packageVersion("stars") > "0.5.4"
+raster_available <- requireNamespace("raster", quietly = TRUE)
 ```
 
 On loading and attaching, **terra** displays its version:
@@ -78,7 +78,7 @@ library("raster")
 `terra::gdal()` tells us the versions of the external libraries being used by **terra**:
 
 ```{r, eval=terra_available}
-gdal(lib="all")
+gdal(lib = "all")
 ```
 
 When using CRAN binary packages built static for Windows and macOS, the R packages will use the same versions of the external libraries, but not necessarily the same versions as those against which GRASS was installed.
@@ -91,7 +91,7 @@ In the **terra** package [@terra], vector data are held in `"SpatVector"` object
 
 
 ```{r, eval=terra_available}
-fv <- system.file("ex/lux.shp", package="terra")
+fv <- system.file("ex/lux.shp", package = "terra")
 (v <- vect(fv))
 ```
 
@@ -124,7 +124,7 @@ v_sf_rt
 ```
 
 ```{r, eval=(terra_available && sf_available)}
-all.equal(v_sf_rt, v, check.attributes=FALSE)
+all.equal(v_sf_rt, v, check.attributes = FALSE)
 ```
 
 ### `"Spatial"`
@@ -138,7 +138,7 @@ print(summary(v_sp))
 
 ```{r, eval=(terra_available && sf_available && sp_available)}
 v_sp_rt <- vect(st_as_sf(v_sp))
-all.equal(v_sp_rt, v, check.attributes=FALSE)
+all.equal(v_sp_rt, v, check.attributes = FALSE)
 ```
 
 ## `"SpatRaster"` coercion
@@ -146,7 +146,7 @@ all.equal(v_sp_rt, v, check.attributes=FALSE)
 In the **terra** package, raster data are held in `"SpatRaster"` objects. This means that when `read_RAST()` is used, a `"SpatRaster"` object is returned, and the same class of object is needed for `write_RAST()` for writing to GRASS.
 
 ```{r, eval=terra_available}
-fr <- system.file("ex/elev.tif", package="terra")
+fr <- system.file("ex/elev.tif", package = "terra")
 (r <- rast(fr))
 ```
 
@@ -173,7 +173,7 @@ which round-trips in memory.
 When coercing to `"stars_proxy"` the same applies:
 
 ```{r, eval=(terra_available && stars_available)}
-(r_stars_p <- st_as_stars(r, proxy=TRUE))
+(r_stars_p <- st_as_stars(r, proxy = TRUE))
 ```
 with coercion from `"stars_proxy"` also not reading data into memory:
 


### PR DESCRIPTION
A suggestion to refactor the codestyle throughout the repo. It has been done with the **styler** package.

I believe this will help contributors (like myself :slightly_smiling_face:) in studying and understanding the existing codebase, as it applies indentation, line breaks, braces, spaces and assignment operators in a consistent manner.

It has been done in two steps in order to better guard for unintended consequences, even though I've never had problems in using **styler**.

As another check, I reran R CMD check with an active GRASS GIS `nc_basic_spm_grass7` location, so that the GRASS GIS dependent examples could run. In this process, a fix has been added to an existing example (8df3a86).